### PR TITLE
added index.js to be picked up by theme/plugin api

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+(function(){
+    "use strict";
+    module.exports = {
+        name: 'Casper',
+        author: 'John O\'Nolan',
+        email: 'john@onolan.org'
+    };
+
+}());


### PR DESCRIPTION
This is needed, as the directory traversal will not pick up the theme otherwise. It's looking for .js files, and stores the module_exports in it. Ghost/106 is still in development though, need to dump the json on the admin end, and sort out linting.

`index.js` can hold arbitrary data. I will look at coming up with defaults that all theme developers will have to adhere to. Ideas welcome.
