### PR TITLE
Adds {{meta_title}} and {{meta_description}} to casper theme

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -6,8 +6,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
     {{! Page Meta }}
-    <title>{{@blog.title}}</title>
-    <meta name="description" content="{{@blog.description}}" />
+    <title>{{meta_title}}</title>
+    <meta name="description" content="{{meta_description}}" />
 
     <meta name="HandheldFriendly" content="True" />
     <meta name="MobileOptimized" content="320" />


### PR DESCRIPTION
- uses meta_title and meta_description helpers rather than @blog.title
