### PR TITLE
Replaced table.plain LESS with equivalent CSS

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -318,12 +318,11 @@ table tbody > tr:nth-child(odd) > th {
     background-color: #f6f6f6;
 }
 
-table.plain {
-    tbody > tr:nth-child(odd) > td,
-    tbody > tr:nth-child(odd) > th {
-        background: transparent;
-    }
+table.plain tbody > tr:nth-child(odd) > td,
+table.plain tbody > tr:nth-child(odd) > th {
+   background: transparent;
 }
+
 
 
 /* ==========================================================================


### PR DESCRIPTION
Looked like there was some LESS formatted CSS that hadn't been compiled. Just replaced with the equivalent CSS.
