### PR TITLE
Added microformats2 h-entry and h-card classnames

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -21,13 +21,13 @@
     {{! Each post will be output using this markup }}
     {{#foreach posts}}
 
-    <article class="{{post_class}}">
+    <article class="h-entry {{post_class}}">
         <header class="post-header">
-            <span class="post-meta"><time datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMM YYYY"}}</time> {{#if tags}}on {{tags}}{{/if}}</span>
-            <h2 class="post-title"><a href="{{url}}">{{{title}}}</a></h2>
+            <span class="post-meta"><time class="dt-published" datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMM YYYY"}}</time> {{#if tags}}on {{tags}}{{/if}}</span>
+            <h2 class=p-name post-title"><a href="{{url}}">{{{title}}}</a></h2>
 
         </header>
-        <section class="post-excerpt">
+        <section class="p-summary post-excerpt">
             <p>{{excerpt}}&hellip;</p>
         </section>
     </article>

--- a/post.hbs
+++ b/post.hbs
@@ -5,7 +5,7 @@
 
 <main class="content" role="main">
 
-    <article class="{{post_class}}">
+    <article class="h-entry {{post_class}}">
 
         {{! Each post has the blog logo at the top, with a link back to the home page }}
         <header class="post-header">
@@ -22,20 +22,20 @@
         {{#post}}
 
         {{! Everything below outputs content of the the post which has been published }}
-        <span class="post-meta"><time datetime="{{date format="YYYY-MM-DD"}}">{{date format='DD MMM YYYY'}}</time> {{#if tags}}on {{tags separator=" | "}}{{/if}}</span>
+        <span class="post-meta"><time class="dt-published" datetime="{{date format="YYYY-MM-DD"}}">{{date format='DD MMM YYYY'}}</time> {{#if tags}}on {{tags separator=" | "}}{{/if}}</span>
 
-        <h1 class="post-title">{{{title}}}</h1>
+        <h1 class="p-name post-title">{{{title}}}</h1>
 
-        <section class="post-content">
+        <section class="e-content post-content">
             {{content}}
         </section>
 
         <footer class="post-footer">
 
             {{#if author}}
-                <section class="author">
-                    <h4>{{author.name}}</h4>
-                    <p>{{author.bio}}</p>
+                <section class="p-author h-card author">
+                    <h4 class="p-name">{{author.name}}</h4>
+                    <p class="p-note">{{author.bio}}</p>
                 </section>
             {{/if}}
 


### PR DESCRIPTION
Added [microformats2](http://microformats.org/wiki/microformats2) classnames into the existing markup structure to make post content machine readable and discoverable. microformats2 makes HTML content as easy to consume as JSON APIs without forcing people to publish data multiple times (DRY violation e.g. ATOM), making things such as cross-site [commenting](http://indiewebcamp.com/comments) easy to build.

Vocabs:
- http://microformats.org/wiki/h-entry for posts
- http://microformats.org/wiki/h-card for author information
