### PR TITLE
Auto height for img in post-content

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -534,6 +534,7 @@ table.plain {
     display: block;
     max-width: 100%;
     margin: 0 auto;
+    height: auto;
 }
 
 /* The author credit area after the post */


### PR DESCRIPTION
The image in the current version of the theme doesn't have the `auto` for the height and the image will look like this https://dl.dropboxusercontent.com/spa/n5v3bx9nnjkdpzf/grkbn1q7.png

After adding the `height: auto;` it will make the image scale correctly.
