### PR TITLE
Fixed font on RSS tooltip

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -736,6 +736,7 @@ table.plain tbody > tr:nth-child(odd) > th {
     top: -23px;
     left: -23px;
     color: rgba(255,255,255,0.9);
+    font-family: 'Open Sans', sans-serif;
     font-size: 1.1rem;
     font-weight: bold;
     line-height: 1em;


### PR DESCRIPTION
As title says.
The icon font overrides the default font thus the RSS tooltip uses the default system font.
