### PR TITLE
Fixed invalid meta tag

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -2,7 +2,7 @@
 <html>
 <head>
     {{! Document Settings }}
-    <meta http-equiv="Content-Type" content="text/html" charset="UTF-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
     {{! Page Meta }}


### PR DESCRIPTION
charset should be declared in the content attribute. This fixes TryGhost/Casper#38
