### PR TITLE
<code>/<tt> elements should wrap since they're used inline

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -238,7 +238,7 @@ code, tt {
     padding: 1px 3px;
     font-family: Inconsolata, monospace, sans-serif;
     font-size: 0.85em;
-    white-space: pre;
+    white-space: pre-wrap;
     border: 1px solid #E3EDF3;
     background: #F7FAFB;
     border-radius: 2px;


### PR DESCRIPTION
This pull request changes the `code, tt` rule `white-space: pre` to `pre-wrap`. [Definitions](http://www.w3.org/TR/CSS21/text.html#white-space-prop):

> **pre**
> This value prevents user agents from collapsing sequences of white space. Lines are only broken at preserved newline characters.
> **pre-wrap**
> This value prevents user agents from collapsing sequences of white space. Lines are broken at preserved newline characters, and as necessary to fill line boxes.

Before:
![white-space: pre](https://f.cloud.github.com/assets/118362/1408033/51d61f12-3d7a-11e3-887b-5ca22839b638.png)

After:
![white-space: pre-wrap](https://f.cloud.github.com/assets/118362/1408034/54e5228e-3d7a-11e3-88e4-b92611842759.png)

See also TryGhost/Ghost#1279.
