### PR TITLE
replaced to html5 charset tag

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -2,7 +2,7 @@
 <html>
 <head>
     {{! Document Settings }}
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
     {{! Page Meta }}


### PR DESCRIPTION
http-equiv="Content-Type" content="text/html" is invalid in HTML5.
