### PR TITLE
removed chrome frame option from meta tag

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -3,7 +3,7 @@
 <head>
     {{! Document Settings }}
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     {{! Page Meta }}
     <title>{{meta_title}}</title>


### PR DESCRIPTION
Google has discontinue the Chrome frame project so I suggest to remove it. Event HTML5 boilerplate has removed it https://github.com/h5bp/html5-boilerplate/commit/8fc26501f4635df92bbbff966d8d6e6064e0e419
