### PR TITLE
Respect the blog URL (and subdirectory) in footer

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -28,7 +28,7 @@
     <footer class="site-footer">
         <a class="subscribe icon-feed" href="{{@blog.url}}/rss/"><span class="tooltip">Subscribe!</span></a>
         <div class="inner">
-             <section class="copyright">All content copyright <a href="/">{{@blog.title}}</a> &copy; {{date format="YYYY"}} &bull; All rights reserved.</section>
+             <section class="copyright">All content copyright <a href="{{@blog.url}}/">{{@blog.title}}</a> &copy; {{date format="YYYY"}} &bull; All rights reserved.</section>
              <section class="poweredby">Proudly published with <a class="icon-ghost" href="http://ghost.org">Ghost</a></section>
         </div>
     </footer>


### PR DESCRIPTION
Currently, the footer links to the website root. This might be intentional (feel free to mercilessly close this), but would cause problems for websites that host multiple Ghost blogs (think of someone with multiple Ghost blogs, perhaps with different authors, with each one existing in a different subdirectory).
