### PR TITLE
Add jQuery to the theme.

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -37,6 +37,7 @@
     {{ghost_foot}}
 
     {{! The main JavaScript file for Casper }}
+    <script type="text/javascript" src="{{asset "shared/vendor/jquery/jquery.js"}}"></script>
     <script type="text/javascript" src="{{asset "js/jquery.fitvids.js"}}"></script>
     <script type="text/javascript" src="{{asset "js/index.js"}}"></script>
 


### PR DESCRIPTION
closes TryGhost/Ghost#1161
- Add a script tag for jQuery directly in the theme, since it’s no longer part of the `ghost_foot` helper.
