### PR TITLE
Added author website link to author's name

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -32,7 +32,13 @@
             <footer class="post-footer">
 
                 <section class="author">
-                    <h4>{{author.name}}</h4>
+                    <h4>
+                        {{#if author.website}}
+                            <a href="{{author.website}}">{{author.name}}</a>
+                        {{else}}
+                            {{author.name}}
+                        {{/if}}
+                    </h4>
                     <p>{{author.bio}}</p>
                 </section>
 


### PR DESCRIPTION
It seemed odd to me that you could set author.website but the default theme never used it.  In this commit I added the website as a link to the author's name, as that seemed like the most appropriate place for it.

It's conditional, so if the user never sets their website it won't linkify the name.
