### PR TITLE
100 pixels is just far too short for logos that aren't very wide. 

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -393,7 +393,7 @@ margin on the iframe, cause it breaks stuff. */
 /* Yo-logo. Yolo-go. Upload one in ghost/settings/ */
 .blog-logo img {
     display: block;
-    max-height: 100px;
+    max-height: 200px;
     width: auto;
     margin: 0 auto;
     line-height: 0;


### PR DESCRIPTION
After playing around with it I think 200 pixels is a better upper bound considering the huge size of the header. It makes a huge difference with smaller square logos. It still seems to look great on phones and tablets as well.

![logo](https://f.cloud.github.com/assets/874394/2232718/0dee0f72-9b20-11e3-8522-2af1bc6f40b6.gif)
