### PR TITLE
Fix for Chrome webfont bug

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -169,6 +169,16 @@ body {
     font-size: 2.0rem;
     line-height: 1.6em;
     color: #3A4145;
+    -webkit-animation-duration: 0.1s;
+    -webkit-animation-name: fontfix;
+    -webkit-animation-iteration-count: 1;
+    -webkit-animation-timing-function: linear;
+    -webkit-animation-delay: 0.1s;
+}
+
+@-webkit-keyframes fontfix {
+   from{ opacity: 1; }
+   to{ opacity: 1; }
 }
 
 ::-moz-selection {


### PR DESCRIPTION
Fix for the bug referenced here - https://code.google.com/p/chromium/issues/detail?id=336476, which causes none of the text that uses a webfont to be drawn.
