### PR TITLE
[RFC] Use hyphens + justify text

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -240,6 +240,15 @@ p, ul, ol, dl {
     margin: 1.6em 0;
 }
 
+p {
+    text-align: justify;
+    -webkit-hyphens: auto;
+    -moz-hyphens: auto;
+    -ms-hyphens: auto;
+    -o-hyphens: auto;
+    hyphens: auto;
+}
+
 ol ol, ul ul,
 ul ol, ol ul {
     margin: 0.4em 0;

--- a/default.hbs
+++ b/default.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     {{! Document Settings }}
     <meta charset="utf-8" />


### PR DESCRIPTION
# Introduction

I know this change might be kind of radical, but let me explain it in detail:

While we want to promote blogs as a new source for information and as an alternative to traditional print media, we never managed to get the same typesetting quality on screen. We selected good fonts, HDPI icons and nice colors. We adjusted margins, paddings, font styles and the reading flow. But we missed one big thing: Left-adjusted text isn't very comfortable to read.

![screenshot from 2014-04-07 19 28 22](https://cloud.githubusercontent.com/assets/1529400/2634519/23798bb8-be7b-11e3-92f2-64a71d6544ce.png)

So let's fix it by making the paragraphs justified:

![screenshot from 2014-04-07 19 29 08](https://cloud.githubusercontent.com/assets/1529400/2634530/3a81fb74-be7b-11e3-951b-8c9f05685d95.png)

That looks much better. But it's still not as great as a printed media. You don't have to use $1000 software or LaTeX to get hyphenation. Even Libre/Open Office [[4]](#footnote-5) and MS Word [[4]](#footnote-4) support it. And there is a working draft [[1]](#footnote-1) for it and some browser [[2]](#footnote-2) support it already:

![screenshot from 2014-04-07 19 29 27](https://cloud.githubusercontent.com/assets/1529400/2634606/1dc4e6b2-be7c-11e3-84e7-5f00e8c1361f.png)

That looks way better and makes Ghost the first modern reading experience I've seen so far :smiley: 
# Technical Details and Problems

There are two major problems here. First of all is that Chrome doesn't support hyphens. So it will fall back to plain justified style. That might look bad is some cases but is still better than the current solution. For more details on browser support see [[2]](#footnote-2)

The second problem is that hyphenation only works if the browser know the language of the document. The reason for this is that the rule set for this technique depends on the language. So I had to add a language tag to the document. Because Ghost only supports English and there is no interface for the theme to get the current main language. So I decided to set English as the document language. While I think that the browser problem isn't really one (we promote this technique and might encourage people around the world to support it) the language problem is one. It would be helpful if the administrator could set the language and the theme could get the language via an interface.

For more details you can also visit [[3]](#footnote-3) I would love to see your comments, suggestions and critics!

**[update 1]**
Setting the document language would also increase accessibility because screen readers and other helper programs can use it to handle the right language. Hyphens do not influence the way screen readers work and copying text is still possible (words get copied like they're not broken).
**[/update 1]**
# References
1. [CSS Working Draft](http://dev.w3.org/csswg/css-text/#hyphens)<a name="footnote-1"></a>
2. [Browser Support](http://caniuse.com/#feat=css-hyphens)<a name="footnote-2"></a>
3. [Explanations by Mozilla](https://developer.mozilla.org/en/docs/Web/CSS/hyphens)<a name="footnote-3"></a>
4. [Microsoft Office: Hyphenation](https://office.microsoft.com/en-us/word-help/hyphenate-text-HP005186492.aspx)<a name="footnote-4"></a>
5. [Libre Office: Hyphenation](https://help.libreoffice.org/Writer/Hyphenation)<a name="footnote-5"></a>
