### PR TITLE
Updating Casper's use of title and author helpers

### DIFF
--- a/author.hbs
+++ b/author.hbs
@@ -2,27 +2,31 @@
 {{! The tag above means - insert everything in this file into the {body} of the default.hbs template }}
 
 {{! The big featured header }}
-<header class="main-header author-head {{#if author.cover}}" style="background-image: url({{author.cover}}){{else}}no-cover{{/if}}">
-    <nav class="main-nav overlay clearfix">
-        <a class="back-button icon-arrow-left" href="{{@blog.url}}">Home</a>
-        <a class="subscribe-button icon-feed" href="{{@blog.url}}/author/{{author.slug}}/rss/">{{author.name}}</a>
-    </nav>
-</header>
 
-<section class="author-profile inner">
-    {{#if author.image}}
-    <figure class="author-image">
-        <div class="img" style="background-image: url({{author.image}})"><span class="hidden">{{author.name}}'s Picture</span></div>
-    </figure>
-    {{/if}}
-    <h1 class="author-title">{{author.name}}</h1>
-    <h2 class="author-bio">{{author.bio}}</h2>
-    <div class="author-meta">
-        {{#if author.location}}<span class="author-location icon-location">{{author.location}}</span>{{/if}}
-        {{#if author.website}}<span class="author-link icon-link"><a href="{{author.website}}">{{author.website}}</a></span>{{/if}}
-        <span class="author-stats"><i class="icon-stats"></i> {{plural pagination.total empty='No posts' singular='% post' plural='% posts'}}</span>
-    </div>
-</section>
+{{! Everything inside the #author tags pulls data from the author }}
+{{#author}}
+    <header class="main-header author-head {{#if cover}}" style="background-image: url({{cover}}){{else}}no-cover{{/if}}">
+        <nav class="main-nav overlay clearfix">
+            <a class="back-button icon-arrow-left" href="{{@blog.url}}">Home</a>
+            <a class="subscribe-button icon-feed" href="{{url}}rss/">{{name}}</a>
+        </nav>
+    </header>
+
+    <section class="author-profile inner">
+        {{#if image}}
+        <figure class="author-image">
+            <div class="img" style="background-image: url({{image}})"><span class="hidden">{{name}}'s Picture</span></div>
+        </figure>
+        {{/if}}
+        <h1 class="author-title">{{name}}</h1>
+        <h2 class="author-bio">{{bio}}</h2>
+        <div class="author-meta">
+            {{#if location}}<span class="author-location icon-location">{{location}}</span>{{/if}}
+            {{#if website}}<span class="author-link icon-link"><a href="{{website}}">{{website}}</a></span>{{/if}}
+            <span class="author-stats"><i class="icon-stats"></i> {{plural ../pagination.total empty='No posts' singular='% post' plural='% posts'}}</span>
+        </div>
+    </section>
+{{/author}}
 
 {{! The main content area on the homepage }}
 <main class="content" role="main">

--- a/page.hbs
+++ b/page.hbs
@@ -11,9 +11,10 @@
 <main class="content" role="main">
 
     <article class="{{post_class}}">
+    {{! Everything inside the #post tags pulls data from the post }}
     {{#post}}
 
-        <h1 class="post-title">{{{title}}}</h1>
+        <h1 class="post-title">{{title}}</h1>
 
         <section class="post-content">
             {{content}}

--- a/post.hbs
+++ b/post.hbs
@@ -15,9 +15,9 @@
     {{#post}}
 
         <header class="post-header">
-            <h1 class="post-title">{{{title}}}</h1>
+            <h1 class="post-title">{{title}}</h1>
             <section class="post-meta">
-                <time class="post-date" datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMMM YYYY"}}</time> {{tags prefix=" on "}} 
+                <time class="post-date" datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMMM YYYY"}}</time> {{tags prefix=" on "}}
             </section>
         </header>
 
@@ -26,9 +26,9 @@
         </section>
 
         <footer class="post-footer">
-        
-        {{! Everything inside the {#with author} tags pulls data from the author }}
-        {{#with author}}
+
+        {{! Everything inside the #author tags pulls data from the author }}
+        {{#author}}
 
             {{#if image}}
             <figure class="author-image">
@@ -38,7 +38,7 @@
 
             <section class="author">
                 <h4><a href="{{url}}">{{name}}</a></h4>
-                
+
                 {{#if bio}}
                     <p>{{bio}}</p>
                 {{else}}
@@ -50,7 +50,7 @@
                 </div>
             </section>
 
-        {{/with}}
+        {{/author}}
 
             <section class="share">
                 <h4>Share this post</h4>


### PR DESCRIPTION
Related to TryGhost/Ghost#3599 and TryGhost/Ghost#3389
- The title helper no longer needs triple-stashes to be safe
- The #author can now be used as a context block again
