### PR TITLE
Swap Noto Serif to PT Serif

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -182,7 +182,7 @@ body {
     font-feature-settings: 'kern' 1;
     height: 100%;
     max-height: 100%;
-    font-family: "Noto Serif", serif;
+    font-family: "PT Serif", serif;
     font-size: 2.2rem;
     line-height: 1.7em;
     color: #3A4145;
@@ -667,7 +667,7 @@ margin on the iframe, cause it breaks stuff. */
     font-size: 2.2rem;
     line-height: 1.5em;
     font-weight: 400;
-    font-family: "Noto Serif", serif;
+    font-family: "PT Serif", serif;
     letter-spacing: 0;
     color: rgba(255,255,255,0.8);
 }
@@ -1144,7 +1144,7 @@ body:not(.post-template) .post-title {
 /* Location, website, and link */
 .author-profile .author-meta {
     margin: 2rem 0;
-    font-family: "Noto Serif", serif;
+    font-family: "PT Serif", serif;
     font-size: 1.7rem;
 }
 .author-meta span {

--- a/default.hbs
+++ b/default.hbs
@@ -16,7 +16,7 @@
 
     {{! Styles'n'Scripts }}
     <link rel="stylesheet" type="text/css" href="{{asset "css/screen.css"}}" />
-    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Noto+Serif:400,700,400italic|Open+Sans:700,400" />
+    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=PT+Serif:400,700,400italic|Open+Sans:700,400" />
 
     {{! Ghost outputs important style and meta data with this tag }}
     {{ghost_head}}


### PR DESCRIPTION
Re: Issue https://github.com/TryGhost/Casper/issues/124 

To prevent the weird IE 10 Win 7 browser issue with Noto Serif and font-feature-settings, change it to PT Serif. 

See comments on the issue for more background on why.
