### PR TITLE
Fix bouncing scroll-down arrow bug in webkit

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -508,6 +508,7 @@ margin on the iframe, cause it breaks stuff. */
     text-align: center;
     text-decoration: none;
     color: rgba(255,255,255,0.7);
+    -webkit-transform: rotate(-90deg);
     transform: rotate(-90deg);
     -webkit-animation: bounce 4s 2s infinite;
     animation: bounce 4s 2s infinite;


### PR DESCRIPTION
Webkit transform currently requires a vendor prefix. Without it, the arrow bounces and rotate to the original un-rotated state. See https://www.dropbox.com/s/46sjiihtjya42s8/wk-rotate.mov
