### PR TITLE
Detailed post typography changes & media queries 

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -222,6 +222,7 @@ h2 {
 
 h3 {
     font-size: 3.2rem;
+    margin-top: 5rem !important;
 }
 
 h4 {
@@ -251,7 +252,7 @@ p, ul, ol, dl {
     -ms-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
     -o-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
     font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
-    margin: 0 0 1.7em 0;
+    margin: 0 0 1.6em 0;
 }
 
 ol, ul {
@@ -656,7 +657,7 @@ margin on the iframe, cause it breaks stuff. */
 /* The details of your blog. Defined in ghost/settings/ */
 .page-title {
     margin: 10px 0 10px 0;
-    font-size: 5.6rem;
+    font-size: 5.5rem;
     letter-spacing: -1px;
     font-weight: 700;
     font-family: "Open Sans", sans-serif;
@@ -1326,7 +1327,7 @@ body:not(.post-template) .post-title {
     }
 
     p, ul, ol, dl {
-        margin: 0 0 1.65em 0;
+        margin: 0 0 1.44em 0;
     }
 
     .post,
@@ -1357,11 +1358,11 @@ body:not(.post-template) .post-title {
     }
 
     h5 {
-        font-size: 2.5rem;
+        font-size: 2.6rem;
     }
 
     h6 {
-        font-size: 2rem;
+        font-size: 2.2rem;
     }
 
     body:not(.post-template) .post-title {
@@ -1433,28 +1434,28 @@ body:not(.post-template) .post-title {
     }
 
     h1 {
-        font-size: 4.5rem;
+        font-size: 4.8rem;
         text-indent: -2px;
     }
 
     h2 {
-        font-size: 3.6rem;
+        font-size: 4rem;
     }
 
     h3 {
-        font-size: 3.1rem;
+        font-size: 3rem;
     }
 
     h4 {
-        font-size: 2.5rem;
+        font-size: 2.4rem;
     }
 
     h5 {
-        font-size: 2.2rem;
+        font-size: 2rem;
     }
 
     h6 {
-        font-size: 1.8rem;
+        font-size: 1.4rem;
     }
 
     .author-profile {
@@ -1621,7 +1622,7 @@ body:not(.post-template) .post-title {
     }
 
     h2 {
-        font-size: 2.6rem;
+        font-size: 3rem;
         letter-spacing: 0;
     }
 
@@ -1630,7 +1631,7 @@ body:not(.post-template) .post-title {
     }
 
     h4 {
-        font-size: 2.1rem;
+        font-size: 2rem;
     }
 
     h5 {
@@ -1638,7 +1639,7 @@ body:not(.post-template) .post-title {
     }
 
     h6 {
-        font-size: 1.7rem;
+        font-size: 1.4rem;
     }
 
     body:not(.post-template) .post-title {


### PR DESCRIPTION
**Changes Made**
- h1, h2, h3, h4, h5, and h6 are all smaller because they were too damn
  big.
- Changed post title size
- Added margin top to h3 because it (h3) looked like the paragraph's
  attached-at-birth twin
- Adjusted media queries so there is a distinctive difference between
  h2, h3 & h4 on post
