### PR TITLE
Fixes to visual bugs on static pages

### DIFF
--- a/page.hbs
+++ b/page.hbs
@@ -3,10 +3,12 @@
 {{! This is a page template. A page outputs content just like any other post, and has all the same
     attributes by default, but you can also customise it to behave differently if you prefer. }}
 
-<nav class="main-nav no-cover clearfix">
-    <a class="back-button icon-arrow-left" href="{{@blog.url}}">Home</a>
-    <a class="subscribe-button icon-feed" href="{{@blog.url}}/rss/">Subscribe</a>
-</nav>
+<header class="main-header post-head {{#if image}}" style="background-image: url({{image}}){{else}}no-cover{{/if}}">
+    <nav class="main-nav {{#if image}}overlay{{/if}} clearfix">
+        <a class="back-button icon-arrow-left" href="{{@blog.url}}">Home</a>
+        <a class="subscribe-button icon-feed" href="{{@blog.url}}/rss/">Subscribe</a>
+    </nav>
+</header>
 
 <main class="content" role="main">
 


### PR DESCRIPTION
Note the background on the Home and Subscribe buttons that are not existent on non-static pages. Also note the missing bottom margin on the post title.
# Static Page

![meetings](https://cloud.githubusercontent.com/assets/15838/4829674/a392f236-5f88-11e4-8b7a-702c679d17a7.png)
# Post Page

![pen shows](https://cloud.githubusercontent.com/assets/15838/4829675/a3938a0c-5f88-11e4-8a92-fb3848f78c18.png)
