### PR TITLE
Support for Pastebin embeds

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1198,6 +1198,10 @@ body:not(.post-template) .post-title {
     font-size: 1.1rem;
 }
 
+/* Pastebin */
+.content .embedPastebin {
+    margin-bottom: 1.75em;
+}
 
 /* ==========================================================================
    8. Pagination - Tools to let you flick between pages


### PR DESCRIPTION
Hello guys and girls,

First and foremost, thanks so much for your hard work on Ghost, Casper and the rest.

Now to business :-) I like to use Pastebin for adding code snippets to my blog. At the moment, there is no margin under the paste, which makes it look kinda weird:

![selection_037](https://cloud.githubusercontent.com/assets/1234006/5232821/7e86e86c-775c-11e4-9901-14158f513773.png)

With the 4 added lines, we get this:

![selection_038](https://cloud.githubusercontent.com/assets/1234006/5232824/c6eb472e-775c-11e4-9f18-763091c0aa67.png)

Any chance we get something _like_ this into Casper ? Would be awesome !

Would it make more sense to try and add support for code snippets somewhat like Github does it, adding the language name after the 3 back ticks, so we get syntax highlighting without the need for embeds ?
