### PR TITLE
RFC: Add lang attribute to html element

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     {{! Document Settings }}
     <meta charset="utf-8" />


### PR DESCRIPTION
## Description
This enables hyphens and text2speech. Without this responsible mobile layout is only partial activated. Especially on small screens, hyphenation can improve readability. Also text2speech is only supported by most software when the language of the content is know. So setting the `lang` attribute also improves accessibility.

Using `en` as a default language makes sense because the template is English as well. Users of other languages might want to change this.

## TODO (later)
Change hardcoded language to templated attribute when i18n is supported. See TryGhost/Ghost#3801 for more details.

## Before
![lang_en_before](https://cloud.githubusercontent.com/assets/1529400/5766009/65889a78-9cfe-11e4-887a-2a1a53359c57.png)

## After
![lang_en_after](https://cloud.githubusercontent.com/assets/1529400/5766014/6eed6706-9cfe-11e4-9e68-d5006f534d58.png)
