### PR TITLE
Add geometricPrecision text-rendering on text elements to support ligatures

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -184,6 +184,7 @@ body {
     -webkit-font-feature-settings: 'kern' 1;
     -moz-font-feature-settings: 'kern' 1;
     -o-font-feature-settings: 'kern' 1;
+    text-rendering: geometricPrecision;
 }
 
 ::-moz-selection {
@@ -203,6 +204,7 @@ h4, h5, h6 {
     line-height: 1.15em;
     margin: 0 0 0.4em 0;
     font-family: "Open Sans", sans-serif;
+    text-rendering: geometricPrecision;
 }
 
 h1 {
@@ -246,6 +248,7 @@ p, ul, ol, dl {
     -moz-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
     -o-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
     margin: 0 0 1.75em 0;
+    text-rendering: geometricPrecision;
 }
 
 ol, ul {


### PR DESCRIPTION
Specifically, added `text-rendering:geometricPrecision` to body, p, h1-h6, ul, ol, and dl.