### PR TITLE
Prefixed second instance of tt with pre

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -349,7 +349,7 @@ pre {
     border-radius: 3px;
 }
 
-pre code, tt {
+pre code, pre tt {
     font-size: inherit;
     white-space: pre-wrap;
     background: transparent;


### PR DESCRIPTION
It's not exactly clear, I could be mistaken, but it seems like the second instance of `tt` should be `pre tt`, otherwise the first set of `tt` rules are rendered mostly useless.