### PR TITLE
Fix copyright footer bug

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1337,7 +1337,6 @@ body:not(.post-template) .post-title {
     -ms-flex-align: stretch;
     align-items: stretch;
     margin-top: 10rem;
-    margin-bottom: calc(-8rem - 37px);
 }
 
 .read-next-story {
@@ -1437,6 +1436,14 @@ body:not(.post-template) .post-title {
     border-left: rgba(0,0,100,0.04) 1px solid;
 }
 
+/* Correctly position site-footer when next to the .read-next container */
+.read-next + .site-footer {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: 0;
+}
 
 /* ==========================================================================
    8. Third Party Elements - Embeds from other services


### PR DESCRIPTION
Closes #196

- Absolutely positions the `.site-footer` when it's adjacent to the `.read-next` container

I've opted to use absolute positioning here because we can't be 10% sure what the height of the footer will be at smaller viewport widths as the `@blog.title` length can vary, so adding loads of breakpoints with negative margins isn't really viable.

[Here's a 1.9mb gif](https://cloud.githubusercontent.com/assets/390392/7178290/8594e9b6-e425-11e4-9754-a4d7f4015ef6.gif)
