### PR TITLE
Social media icons with brand colors on hover

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1185,8 +1185,14 @@ body:not(.post-template) .post-title {
     text-decoration: none;
 }
 
-.post-footer .share a:hover {
-    color: #50585D;
+.post-footer .share .icon-twitter:hover {
+    color: #55acee;
+}
+.post-footer .share .icon-facebook:hover {
+    color: #3b5998;
+}
+.post-footer .share .icon-google-plus:hover {
+    color: #dd4b39;
 }
 
 


### PR DESCRIPTION
Hi,

According to http://brandcolors.net/,

IMHO, the "very dark grayish blue" color on hover of the social media icons is not fantastic and it could be a better secondary call-to-action by using the official brand colors on hover:
- #55acee for Twitter
- #3b5998 for Facebook
- #dd4b39 for Google+

You could see the difference:
![social-media-icons](https://cloud.githubusercontent.com/assets/2359059/7221045/20a271bc-e6dd-11e4-8b8f-19d1c5dacf3d.jpg)
