### PR TITLE
Remove border from menu button on small screens

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1773,7 +1773,7 @@ body:not(.post-template) .post-title {
     .menu-button {
         padding: 0 5px;
         border-radius: 0;
-        border-color: transparent;
+        border-width: 0;
         color: #2e2e2e;
         background: transparent;
     }


### PR DESCRIPTION
No issue

In #189 I reworked much of the CSS for the menu button. The border on the menu button is supposed to be removed on small screens, but I missed that. This removes it.