### PR TITLE
Added data attribute with post UUID to article element in post template

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -16,7 +16,7 @@
 </header>
 
 <main class="content" role="main">
-    <article class="{{post_class}}">
+    <article class="{{post_class}}" data-post-id="{{uuid}}">
 
         <header class="post-header">
             <h1 class="post-title">{{title}}</h1>


### PR DESCRIPTION
Having the Post UUID available in the template will make it available for use by code injection scripts that can make valuable use of it. Specifically, [I've created one](https://gist.github.com/ryexley/4e7ad06d9ce5f9014423) that injects Disqus comments on post pages that could really benefit from having the post UUID available for use in the `disqus_identifier` variable to allow Disqus to uniquely identify the post it associates comments with.