### PR TITLE
Add jQuery, as this is being removed from Ghost

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -40,8 +40,9 @@
     {{! Ghost outputs important scripts and data with this tag }}
     {{ghost_foot}}
 
-    {{! The main JavaScript file for Casper }}
+    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
     <script type="text/javascript" src="{{asset "js/jquery.fitvids.js"}}"></script>
+    {{! The main JavaScript file for Casper }}
     <script type="text/javascript" src="{{asset "js/index.js"}}"></script>
 
 </body>


### PR DESCRIPTION
refs TryGhost/Ghost#5298

If jQuery is present in the user's `ghost_foot` setting, a duplicate tag will appear, but as we're using the same file, all modern browsers will ignore the second one.