### PR TITLE
Move jQuery before `{{ghost_foot}}`

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -37,10 +37,11 @@
 
     </div>
 
+    {{!-- jQuery needs to come before `{{ghost_foot}}` so that jQuery can be used in code injection --}}
+    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
     {{! Ghost outputs important scripts and data with this tag }}
     {{ghost_foot}}
 
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
     <script type="text/javascript" src="{{asset "js/jquery.fitvids.js"}}"></script>
     {{! The main JavaScript file for Casper }}
     <script type="text/javascript" src="{{asset "js/index.js"}}"></script>


### PR DESCRIPTION
- Including jQuery before `{{ghost_foot}}` means jQuery can be used inside ghost_foot code injection
- It should also improve backwards compat, as without this jQuery code included via ghost_foot may break