### PR TITLE
Added mathjax and syntax highlighting integrations

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -46,5 +46,17 @@
     {{! The main JavaScript file for Casper }}
     <script type="text/javascript" src="{{asset "js/index.js"}}"></script>
 
+    {{! Mathjax configuration}}
+    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+
+    <script type="text/x-mathjax-config">  
+    MathJax.Hub.Config({  
+        tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+    });
+    </script>
+
+    {{! Syntax Highlighting }}
+    <script src="https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js"></script>
+
 </body>
 </html>


### PR DESCRIPTION
As more and more people are using it, I find it's a good idea to add in the 
mathjax and syntax highlighting integrations into casper.
It would also solve the issues recurring with people who try to integrate these fixes while hosting
ghost on Heroku and other deployment PAAS.