### PR TITLE
Disable discretionary ligatures in headings

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -206,9 +206,9 @@ body {
 
 h1, h2, h3,
 h4, h5, h6 {
-    -webkit-font-feature-settings: 'dlig' 1, 'liga' 1, 'lnum' 1, 'kern' 1;
-    -moz-font-feature-settings: 'dlig' 1, 'liga' 1, 'lnum' 1, 'kern' 1;
-    -o-font-feature-settings: 'dlig' 1, 'liga' 1, 'lnum' 1, 'kern' 1;
+    -webkit-font-feature-settings: 'liga' 1, 'lnum' 1, 'kern' 1;
+    -moz-font-feature-settings: 'liga' 1, 'lnum' 1, 'kern' 1;
+    -o-font-feature-settings: 'liga' 1, 'lnum' 1, 'kern' 1;
     color: #2E2E2E;
     line-height: 1.15em;
     margin: 0 0 0.4em 0;


### PR DESCRIPTION
Hi, I propose to disable `discretionary ligatures` in heading style because of following reasons: 

1. `Open Sans` is used for heading font face, but the font does not have discretionary ligatures AFAIK, though it has usual ligatures (`liga`).

2. For the letters other than English, it will be default to their `sans-serif` fonts, and the ligature specification might cause unexpected concatenations. Here's some funny Japanese examples:

 **Expected**: Word for "build"  
 ![Build](https://c2.staticflickr.com/2/1547/24139210001_3a8b9f9ee5_o.png)

 **Failed**: Consolidated character for "building" (used in media with limited space e.g. newspapers) + sound "do"  
 ![Building + do](https://c2.staticflickr.com/2/1684/24113725592_d7692e4cac_o.png)

 **Expected**: Word for "france"  
 ![France](https://c2.staticflickr.com/2/1592/24139209991_5803b76927_o.png)

 **Failed**: The set for "franc" + sound "su"  
 ![Franc + su](https://c2.staticflickr.com/2/1539/23926198220_3d959272f8_o.png)
 
 I am not sure if such a things happen in other languages, but discretionary ligatures is discretional, so I think it should not be specified in default except the font covers (almost) all language and we know how it combines the characters.
