### PR TITLE
Disable ligatures in code blocks

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -344,6 +344,9 @@ code, tt {
     border: #E3EDF3 1px solid;
     background: #F7FAFB;
     border-radius: 2px;
+    -webkit-font-feature-settings: "liga" 0;
+    -moz-font-feature-settings: "liga" 0;
+    font-feature-settings: "liga" 0;
 }
 
 pre {


### PR DESCRIPTION
I recently created a new Ghost blog and a colleague pointed out that ligatures for code blocks looked a bit off due to the monospaced font. They weren't enabled in Firefox by default, but in Chrome (possibly different browser defaults?). This PR standardises it and removes any ligatures from `<code>` and `<tt>` blocks.

Before:
<img width="228" alt="A block of code with ligatures enabled" src="https://cloud.githubusercontent.com/assets/1315463/12465368/93644920-bfc5-11e5-9eff-610819998630.png">

After:
<img width="234" alt="A block of code with ligatures disabled" src="https://cloud.githubusercontent.com/assets/1315463/12465365/934694de-bfc5-11e5-85ed-168d3d30ac72.png">

