### PR TITLE
Update libraries to lastest version and minor fix

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -22,82 +22,80 @@
 */
 
 /* ==========================================================================
-   0. Normalize.css v2.1.3 | MIT License | git.io/normalize | (minified)
+   0. normalize.css v3.0.3 | MIT License | git.io/normalize | (minified)
    ========================================================================== */
 
-article, aside, details,
-figcaption, figure,
-footer, header, hgroup,
-main, nav, section,
-summary { display: block; }
-audio, canvas, video { display: inline-block; }
-audio:not([controls]) { display: none; height: 0; }
-[hidden], template { display: none; }
-html {
-   font-family: sans-serif;
-   -ms-text-size-adjust: 100%;
-   -webkit-text-size-adjust: 100%;
+html { 
+    font-family: sans-serif;
+    -ms-text-size-adjust: 100%;
+    -webkit-text-size-adjust: 100%
 }
 body { margin: 0; }
-a { background: transparent; }
-a:focus { outline: thin dotted; }
-a:active, a:hover { outline: 0; }
-h1 { font-size: 2em; margin: 0.67em 0; }
-abbr[title] { border-bottom: 1px dotted; }
-b, strong { font-weight: 700; }
-dfn { font-style: italic; }
-hr {
-   -moz-box-sizing: content-box;
-   box-sizing: content-box;
-   height: 0;
+article, aside, details,
+figcaption, figure,
+footer, header,
+main, menu, nav,
+section, summary { display:block; }
+audio, canvas, progress, video {
+    display: inline-block;
+    vertical-align: baseline;
 }
-mark { background: #FF0; color: #000; }
-code, kbd, pre,
-samp { font-family: monospace, serif; font-size: 1em; }
-pre { white-space: pre-wrap; }
-q { quotes: "\201C" "\201D" "\2018" "\2019"; }
+audio:not([controls]) { display: none; height: 0; }
+[hidden], template { display: none; }
+a { background-color: transparent;}
+a:active, a:hover { outline: 0; }
+abbr[title] { border-bottom: 1px dotted; }
+b, strong { font-weight: bold; }
+dfn { font-style: italic; }
+h1 { font-size: 2em; margin: 0.67em 0; }
+mark { background: #ff0; color: #000; }
 small { font-size: 80%; }
 sub, sup {
-   font-size: 75%;
-   line-height: 0;
-   position: relative;
-   vertical-align: baseline;
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
 }
 sup { top: -0.5em; }
 sub { bottom: -0.25em; }
 img { border: 0; }
 svg:not(:root) { overflow: hidden; }
-figure { margin: 0; }
-fieldset {
-   border: 1px solid #c0c0c0;
-   margin: 0 2px;
-   padding: 0.35em 0.625em 0.75em;
+figure { margin: 1em 40px; }
+hr { box-sizing: content-box; height: 0; }
+pre { overflow: auto; }
+code, kbd, pre, samp { font-family: monospace, monospace; font-size: 1em; }
+button, input, optgroup, select, textarea {
+    color: inherit;
+    font: inherit;
+    margin: 0;
 }
-legend { border: 0; padding: 0; }
-button, input, select,
-textarea { font-family: inherit; font-size: 100%; margin: 0; }
-button, input { line-height: normal; }
+button { overflow: visible; }
 button, select { text-transform: none; }
-button, html input[type="button"],
+button, html input[type="button"], 
 input[type="reset"], input[type="submit"] {
-   -webkit-appearance: button;
-   cursor: pointer;
+    -webkit-appearance: button;
+    cursor: pointer;
 }
 button[disabled], html input[disabled] { cursor: default; }
+button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
+input { line-height: normal; }
 input[type="checkbox"],
 input[type="radio"] { box-sizing: border-box; padding: 0; }
-input[type="search"] {
-   -webkit-appearance: textfield;
-   -moz-box-sizing: content-box;
-   -webkit-box-sizing: content-box;
-   box-sizing: content-box;
-}
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button { height: auto; }
+input[type="search"] { -webkit-appearance: textfield; }
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
-button::-moz-focus-inner,
-input::-moz-focus-inner { border: 0; padding: 0; }
-textarea { overflow: auto; vertical-align: top; }
-table { border-collapse: collapse; border-spacing: 0; }
+fieldset {
+    border: 1px solid #c0c0c0;
+    margin: 0 2px;
+    padding: 0.35em 0.625em 0.75em;
+}
+legend { border: 0; padding: 0; }
+textarea { overflow: auto; }
+optgroup { font-weight: bold; }
+table{ border-collapse: collapse; border-spacing: 0; }
+td, th{ padding: 0; }
 
 
 /* ==========================================================================
@@ -185,41 +183,41 @@ html {
 body {
     height: 100%;
     max-height: 100%;
-    font-family: "Merriweather", serif;
-    letter-spacing: 0.01rem;
+    color: #3a4145;
     font-size: 1.8rem;
     line-height: 1.75em;
-    color: #3A4145;
+    font-family: "Merriweather", serif;
+    letter-spacing: 0.01rem;
     -webkit-font-feature-settings: 'kern' 1;
-    -moz-font-feature-settings: 'kern' 1;
-    -o-font-feature-settings: 'kern' 1;
+       -moz-font-feature-settings: 'kern' 1;
+         -o-font-feature-settings: 'kern' 1;
     text-rendering: geometricPrecision;
 }
 
 ::-moz-selection {
-    background: #D6EDFF;
+    background: #d6edff;
 }
 
 ::selection {
-    background: #D6EDFF;
+    background: #d6edff;
 }
 
 h1, h2, h3,
 h4, h5, h6 {
-    -webkit-font-feature-settings: 'dlig' 1, 'liga' 1, 'lnum' 1, 'kern' 1;
-    -moz-font-feature-settings: 'dlig' 1, 'liga' 1, 'lnum' 1, 'kern' 1;
-    -o-font-feature-settings: 'dlig' 1, 'liga' 1, 'lnum' 1, 'kern' 1;
-    color: #2E2E2E;
-    line-height: 1.15em;
     margin: 0 0 0.4em 0;
+    color: #2e2e2e;
+    line-height: 1.15em;
     font-family: "Open Sans", sans-serif;
+    -webkit-font-feature-settings: 'dlig' 1, 'liga' 1, 'lnum' 1, 'kern' 1;
+       -moz-font-feature-settings: 'dlig' 1, 'liga' 1, 'lnum' 1, 'kern' 1;
+         -o-font-feature-settings: 'dlig' 1, 'liga' 1, 'lnum' 1, 'kern' 1;
     text-rendering: geometricPrecision;
 }
 
 h1 {
     font-size: 5rem;
-    letter-spacing: -2px;
     text-indent: -3px;
+    letter-spacing: -2px;
 }
 
 h2 {
@@ -244,7 +242,7 @@ h6 {
 }
 
 a {
-    color: #4A4A4A;
+    color: #4a4a4a;
     transition: color 0.3s ease;
 }
 
@@ -253,10 +251,10 @@ a:hover {
 }
 
 p, ul, ol, dl {
-    -webkit-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
-    -moz-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
-    -o-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
     margin: 0 0 1.75em 0;
+    -webkit-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
+       -moz-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
+         -o-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
     text-rendering: geometricPrecision;
 }
 
@@ -266,25 +264,25 @@ ol, ul {
 
 ol ol, ul ul,
 ul ol, ol ul {
-    margin: 0 0 0.4em 0;
     padding-left: 2em;
+    margin: 0 0 0.4em 0;
 }
 
 dl dt {
     float: left;
-    width: 180px;
-    overflow: hidden;
     clear: left;
+    overflow: hidden;
+    width: 180px;
+    margin-bottom: 1em;
+    font-weight: 700;
     text-align: right;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-weight: 700;
-    margin-bottom: 1em;
 }
 
 dl dd {
+    margin-bottom: 1em;
     margin-left: 200px;
-    margin-bottom: 1em
 }
 
 li {
@@ -298,18 +296,18 @@ li li {
 hr {
     display: block;
     height: 1px;
-    border: 0;
-    border-top: #EFEFEF 1px solid;
-    margin: 3.2em 0;
     padding: 0;
+    border: 0;
+    border-top: 1px solid #efefef;
+    margin: 3.2em 0;
 }
 
 blockquote {
     -moz-box-sizing: border-box;
-    box-sizing: border-box;
-    margin: 1.75em 0 1.75em -2.2em;
+         box-sizing: border-box;
     padding: 0 0 0 1.75em;
-    border-left: #4A4A4A 0.4em solid;
+    border-left: 0.4em solid #4a4a4a;
+    margin: 1.75em 0 1.75em -2.2em;
 }
 
 blockquote p {
@@ -320,15 +318,13 @@ blockquote p {
 blockquote small {
     display: inline-block;
     margin: 0.8em 0 0.8em 1.5em;
+    color: #ccc;
     font-size: 0.9em;
-    color: #CCC;
 }
 
 blockquote small:before { content: "\2014 \00A0"; }
 
-blockquote cite {
-    font-weight: 700;
-}
+blockquote cite { font-weight: 700; }
 
 blockquote cite a { font-weight: normal; }
 
@@ -338,72 +334,70 @@ mark {
 
 code, tt {
     padding: 1px 3px;
-    font-family: Inconsolata, monospace, sans-serif;
-    font-size: 0.85em;
-    white-space: pre-wrap;
-    border: #E3EDF3 1px solid;
-    background: #F7FAFB;
+    border: 1px solid #e3edf3;
     border-radius: 2px;
+    background: #f7fafb;
+    font-size: 0.85em;
+    font-family: Inconsolata, monospace, sans-serif;
     -webkit-font-feature-settings: "liga" 0;
-    -moz-font-feature-settings: "liga" 0;
-    font-feature-settings: "liga" 0;
+       -moz-font-feature-settings: "liga" 0;
+            font-feature-settings: "liga" 0;
+    white-space: pre-wrap;
 }
 
 pre {
+    overflow: auto;
     -moz-box-sizing: border-box;
-    box-sizing: border-box;
-    margin: 0 0 1.75em 0;
-    border: #E3EDF3 1px solid;
+         box-sizing: border-box;
     width: 100%;
     padding: 10px;
-    font-family: Inconsolata, monospace, sans-serif;
-    font-size: 0.9em;
-    white-space: pre;
-    overflow: auto;
-    background: #F7FAFB;
+    border: 1px solid #e3edf3;
     border-radius: 3px;
+    margin: 0 0 1.75em 0;
+    background: #f7fafb;
+    font-size: 0.9em;
+    font-family: Inconsolata, monospace, sans-serif;
+    white-space: pre;
 }
 
 pre code, pre tt {
+    padding: 0;
+    border: 0;
+    background: transparent;
     font-size: inherit;
     white-space: pre-wrap;
-    background: transparent;
-    border: none;
-    padding: 0;
 }
 
 kbd {
     display: inline-block;
-    margin-bottom: 0.4em;
     padding: 1px 8px;
-    border: #CCC 1px solid;
-    color: #666;
-    text-shadow: #FFF 0 1px 0;
-    font-size: 0.9em;
-    font-weight: 700;
-    background: #F4F4F4;
+    border: 1px solid #ccc;
     border-radius: 4px;
-    box-shadow:
-        0 1px 0 rgba(0, 0, 0, 0.2),
-        0 1px 0 0 #fff inset;
+    margin-bottom: 0.4em;
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), inset 0 1px 0 0 #fff;
+    background: #f4f4f4;
+    color: #666;
+    font-weight: 700;
+    font-size: 0.9em;
+    text-shadow: #fff 0 1px 0;
 }
 
 table {
     -moz-box-sizing: border-box;
-    box-sizing: border-box;
-    margin: 1.75em 0;
+         box-sizing: border-box;
     width: 100%;
     max-width: 100%;
+    margin: 1.75em 0;
     background-color: transparent;
 }
 
 table th,
 table td {
     padding: 8px;
+    border-top: 1px solid #efefef;
     line-height: 20px;
     text-align: left;
     vertical-align: top;
-    border-top: #EFEFEF 1px solid;
 }
 
 table th { color: #000; }
@@ -417,13 +411,13 @@ table thead:first-child tr:first-child td {
     border-top: 0;
 }
 
-table tbody + tbody { border-top: #EFEFEF 2px solid; }
+table tbody + tbody { border-top: 2px solid #efefef; }
 
-table table table { background-color: #FFF; }
+table table table { background-color: #fff; }
 
 table tbody > tr:nth-child(odd) > td,
 table tbody > tr:nth-child(odd) > th {
-    background-color: #F6F6F6;
+    background-color: #f6f6f6;
 }
 
 table.plain tbody > tr:nth-child(odd) > td,
@@ -450,17 +444,17 @@ margin on the iframe, cause it breaks stuff. */
 /* Clears shit */
 .clearfix:before,
 .clearfix:after {
-    content: " ";
     display: table;
+    content: ' ';
 }
 .clearfix:after { clear: both; }
 .clearfix { zoom: 1; }
 
 /* Hides shit */
 .hidden {
+    display: none;
     text-indent: -9999px;
     visibility: hidden;
-    display: none;
 }
 
 /* Creates a responsive wrapper that makes our content scale nicely */
@@ -505,13 +499,13 @@ body.nav-opened .site-wrapper {
 .main-header {
     position: relative;
     display: table;
+    overflow: hidden;
     width: 100%;
     height: 100vh;
     margin-bottom: 5rem;
-    text-align: center;
     background: #222 no-repeat center center;
     background-size: cover;
-    overflow: hidden;
+    text-align: center;
 }
 
 .main-header .inner {
@@ -525,36 +519,34 @@ body.nav-opened .site-wrapper {
 }
 
 .main-nav a {
-    text-decoration: none;
     font-family: 'Open Sans', sans-serif;
+    text-decoration: none;
 }
 
 /* Navigation */
 body.nav-opened .nav-cover {
     position: fixed;
+    z-index: 200;
     top: 0;
-    left: 0;
     right: 240px;
     bottom: 0;
-    z-index: 200;
+    left: 0;
 }
 
 .nav {
     position: fixed;
+    z-index: 5;
     top: 0;
     right: 0;
     bottom: 0;
-    z-index: 5;
     width: 240px;
     opacity: 0;
-    background: #111;
-    margin-bottom: 0;
-    text-align: left;
     overflow-y: auto;
-    -webkit-transition: -webkit-transform 0.5s ease,
-                        opacity 0.3s ease 0.7s;
-            transition: transform 0.5s ease,
-                        opacity 0.3s ease 0.7s;
+    margin-bottom: 0;
+    background: #111;
+    text-align: left;
+    -webkit-transition: -webkit-transform 0.5s ease, opacity 0.3s ease 0.7s;
+            transition: transform 0.5s ease, opacity 0.3s ease 0.7s;
 }
 
 body.nav-closed .nav {
@@ -565,10 +557,8 @@ body.nav-closed .nav {
 
 body.nav-opened .nav {
     opacity: 1;
-    -webkit-transition: -webkit-transform 0.3s ease,
-                        opacity 0s ease 0s;
-            transition: transform 0.3s ease,
-                        opacity 0s ease 0s;
+    -webkit-transition: -webkit-transform 0.3s ease, opacity 0s ease 0s;
+            transition: transform 0.3s ease, opacity 0s ease 0s;
     -webkit-transform: translate3D(0, 0, 0);
         -ms-transform: translate3D(0, 0, 0);
             transform: translate3D(0, 0, 0);
@@ -578,10 +568,10 @@ body.nav-opened .nav {
     position: absolute;
     top: 45px;
     left: 30px;
-    font-size: 16px;
-    font-weight: 100;
-    text-transform: uppercase;
     color: #fff;
+    font-weight: 100;
+    font-size: 16px;
+    text-transform: uppercase;
 }
 
 .nav-close {
@@ -600,15 +590,14 @@ body.nav-opened .nav {
 
 .nav-close:before,
 .nav-close:after {
-    content: '';
     position: absolute;
-    top: 0;
+    top: 15px;
     width: 20px;
     height: 1px;
     background: rgb(150,150,150);
-    top: 15px;
     -webkit-transition: background 0.15s ease;
             transition: background 0.15s ease;
+    content: '';
 }
 
 .nav-close:before {
@@ -629,20 +618,19 @@ body.nav-opened .nav {
 }
 
 .nav ul {
-    padding: 90px 9% 5%;
     list-style: none;
+    padding: 90px 9% 5%;
     counter-reset: item;
 }
 
 .nav li:before {
-    display: block;
     float: right;
     padding-right: 4%;
     padding-left: 5px;
-    text-align: right;
-    font-size: 1.2rem;
-    vertical-align: bottom;
     color: #B8B8B8;
+    font-size: 1.2rem;
+    text-align: right;
+    vertical-align: bottom;
     content: counter(item, lower-roman);
     counter-increment: item;
 }
@@ -650,29 +638,29 @@ body.nav-opened .nav {
     margin: 0;
 }
 .nav li a {
-    text-decoration: none;
-    line-height: 1.4;
-    font-size: 1.4rem;
     display: block;
-    padding: 0.6rem 4%;
     overflow: hidden;
+    padding: 0.6rem 4%;
+    font-size: 1.4rem;
+    line-height: 1.4;
+    text-decoration: none;
     white-space: nowrap;
     text-overflow: ellipsis;
 }
 .nav li a:after {
     display: inline-block;
-    content: " .......................................................";
-    color: rgba(255,255,255,0.2);
     margin-left: 5px;
+    color: rgba(255,255,255,0.2);
+    content: ' .......................................................';
 }
 .nav .nav-current:before {
     color: #fff;
 }
 .nav .nav-current a:after {
-    content: " ";
-    border-bottom: rgba(255,255,255,0.5) 1px solid;
     width: 100%;
     height: 1px;
+    border-bottom: 1px solid rgba(255,255,255,0.5);
+    content: ' ';
 }
 
 .nav a:link,
@@ -688,74 +676,74 @@ body.nav-opened .nav {
 }
 
 .subscribe-button {
+    position: absolute;
+    right: 30px;
+    bottom: 30px;
+    left: 30px;
+    display: block;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
-    display: block;
-    position: absolute;
-    bottom: 30px;
-    left: 30px;
-    right: 30px;
     height: 38px;
     padding: 0 20px;
-    color: #111 !important; /* Overides `.nav a:link, .nav a:visited` colour */
-    text-align: center;
-    font-size: 12px;
-    font-family: "Open Sans", sans-serif;
-    text-transform: uppercase;
-    text-decoration: none;
-    line-height: 35px;
     border-radius: 3px;
     background: #fff;
+    color: #111 !important; /* Overides `.nav a:link, .nav a:visited` colour */
+    font-size: 12px;
+    font-family: "Open Sans", sans-serif;
+    line-height: 35px;
+    text-align: center;
+    text-transform: uppercase;
+    text-decoration: none;
     transition: all ease 0.3s;
 }
 .subscribe-button:before {
-    font-size: 9px;
     margin-right: 6px;
+    font-size: 9px;
 }
 
 
 /* Create a bouncing scroll-down arrow on homepage with cover image */
 .scroll-down {
-    display: block;
     position: absolute;
     z-index: 100;
     bottom: 45px;
     left: 50%;
-    margin-left: -16px;
+    display: block;
     width: 34px;
     height: 34px;
+    margin-left: -16px;
+    color: rgba(255,255,255,0.7);
     font-size: 34px;
     text-align: center;
     text-decoration: none;
-    color: rgba(255,255,255,0.7);
     -webkit-transform: rotate(-90deg);
-    -ms-transform: rotate(-90deg);
-    transform: rotate(-90deg);
+        -ms-transform: rotate(-90deg);
+            transform: rotate(-90deg);
     -webkit-animation: bounce 4s 2s infinite;
-    animation: bounce 4s 2s infinite;
+            animation: bounce 4s 2s infinite;
 }
 
 /* Stop it bouncing and increase contrast when hovered */
 .scroll-down:hover {
     color: #fff;
     -webkit-animation: none;
-    animation: none;
+            animation: none;
 }
 
 /* Put a semi-opaque radial gradient behind the icon to make it more visible
    on photos which happen to have a light background. */
 .home-template .main-header:after {
-    display: block;
-    content: " ";
-    width: 150px;
-    height: 130px;
-    border-radius: 100%;
     position: absolute;
     bottom: 0;
     left: 50%;
+    display: block;
+    width: 150px;
+    height: 130px;
+    border-radius: 100%;
     margin-left: -75px;
     background: radial-gradient(ellipse at center,  rgba(0,0,0,0.15) 0%,rgba(0,0,0,0) 70%,rgba(0,0,0,0) 100%);
+    content: ' ';
 }
 
 /* Hide when there's no cover image or on page2+ */
@@ -763,52 +751,51 @@ body.nav-opened .nav {
 .no-cover.main-header:after,
 .archive-template .scroll-down,
 .archive-template .main-header:after {
-    display: none
+    display: none; 
 }
 
 /* Appears in the top left corner of your home page */
 .blog-logo {
-    display: block;
     float: left;
     background: none !important; /* Makes sure there is never a background */
     border: none !important; /* Makes sure there is never a border */
 }
 
 .blog-logo img {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     display: block;
+    -webkit-box-sizing: border-box;
+       -moz-box-sizing: border-box;
+            box-sizing: border-box;
+    width: auto;
     height: 38px;
     padding: 1px 0 5px 0;
-    width: auto;
 }
 
 .menu-button {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     display: inline-block;
+    -webkit-box-sizing: border-box;
+       -moz-box-sizing: border-box;
+            box-sizing: border-box;
     float: right;
     height: 38px;
     padding: 0 15px;
-    border-style: solid;
     border-width: 1px;
-    opacity: 1;
-    text-align: center;
-    font-size: 12px;
-    text-transform: uppercase;
-    line-height: 35px;
-    white-space: nowrap;
+    border-style: solid;
     border-radius: 3px;
+    opacity: 1;
+    font-size: 12px;
+    line-height: 35px;
+    text-align: center;
+    text-transform: uppercase;
+    white-space: nowrap;
     transition: all 0.5s ease;
 }
 .menu-button:before {
-    font-size: 12px;
-    font-weight: bold;
-    margin-right: 6px;
     position: relative;
     top: 1px;
+    margin-right: 6px;
+    font-weight: 700;
+    font-size: 12px;
 }
 .menu-button:hover {
     background: #fff;
@@ -819,8 +806,8 @@ body.nav-opened .nav {
 
 /* When the navigation is closed */
 .nav-closed .menu-button {
-    color: #fff;
     border-color: rgba(255, 255, 255, 0.6);
+    color: #fff;
 }
 .nav-closed .menu-button:hover {
     color: #222;
@@ -828,8 +815,8 @@ body.nav-opened .nav {
 
 /* When the navigation is closed and there is no cover image */
 .nav-closed .no-cover .menu-button {
-    border-color: #BFC8CD;
-    color: #9EABB3;
+    border-color: #bfc8cd;
+    color: #9eabb3;
 }
 .nav-closed .no-cover .menu-button:hover {
     border-color: #555;
@@ -839,8 +826,8 @@ body.nav-opened .nav {
 /* When the navigation is opened */
 .nav-opened .menu-button {
     padding: 0 12px;
-    background: #111;
     border-color: #111;
+    background: #111;
     color: #fff;
     -webkit-transform: translate3D(94px, 0, 0);
         -ms-transform: translate3D(94px, 0, 0);
@@ -857,10 +844,10 @@ body.nav-opened .nav {
 .main-nav.overlay {
     position: absolute;
     top: 0;
-    left: 0;
     right: 0;
+    left: 0;
     height: 70px;
-    border: none;
+    border: 0;
     background: linear-gradient(to bottom, rgba(0,0,0,0.2) 0%,rgba(0,0,0,0) 100%);
 }
 .no-cover .main-nav.overlay {
@@ -870,21 +857,21 @@ body.nav-opened .nav {
 /* The details of your blog. Defined in ghost/settings/ */
 .page-title {
     margin: 10px 0 10px 0;
-    font-size: 5rem;
-    letter-spacing: -1px;
-    font-weight: 700;
-    font-family: "Open Sans", sans-serif;
     color: #fff;
+    font-weight: 700;
+    font-size: 5rem;
+    font-family: "Open Sans", sans-serif;
+    letter-spacing: -1px;
 }
 
 .page-description {
     margin: 0;
+    color: rgba(255,255,255,0.8);
+    font-weight: 400;
     font-size: 2rem;
     line-height: 1.5em;
-    font-weight: 400;
     font-family: "Merriweather", serif;
     letter-spacing: 0.01rem;
-    color: rgba(255,255,255,0.8);
 }
 
 .no-cover.main-header {
@@ -904,15 +891,15 @@ body.nav-opened .nav {
 /* Add subtle load-in animation for content on the home page */
 .home-template .page-title {
     -webkit-animation: fade-in-down 0.6s;
-    animation: fade-in-down 0.6s;
+            animation: fade-in-down 0.6s;
     -webkit-animation-delay: 0.2s;
-    animation-delay: 0.2s;
+            animation-delay: 0.2s;
 }
 .home-template .page-description {
     -webkit-animation: fade-in-down 0.9s;
-    animation: fade-in-down 0.9s;
+            animation: fade-in-down 0.9s;
     -webkit-animation-delay: 0.1s;
-    animation-delay: 0.1s;
+            animation-delay: 0.1s;
 }
 
 /* Every post, on every page, gets this style on its <article> tag */
@@ -920,27 +907,27 @@ body.nav-opened .nav {
     position: relative;
     width: 80%;
     max-width: 710px;
-    margin: 4rem auto;
     padding-bottom: 4rem;
-    border-bottom: #EBF2F6 1px solid;
+    border-bottom: 1px solid #ebf2f6;
+    margin: 4rem auto;
     word-wrap: break-word;
 }
 
 /* Add a little circle in the middle of the border-bottom on our .post
    just for the lolz and stylepoints. */
 .post:after {
-    display: block;
-    content: "";
-    width: 7px;
-    height: 7px;
-    border: #E7EEF2 1px solid;
     position: absolute;
     bottom: -5px;
     left: 50%;
-    margin-left: -5px;
-    background: #FFF;
+    display: block;
+    width: 7px;
+    height: 7px;
+    border: 1px solid #e7eef2;
     border-radius: 100%;
-    box-shadow: #FFF 0 0 0 5px;
+    margin-left: -5px;
+    box-shadow: 0 0 0 5px #fff;
+    background: #fff;
+    content: '';
 }
 
 body:not(.post-template) .post-title {
@@ -964,22 +951,22 @@ body:not(.post-template) .post-title {
 .post-meta {
     display: block;
     margin: 1.75rem 0 0 0;
-    font-family: "Open Sans", sans-serif;
+    color: #9eabb3;
     font-size: 1.5rem;
     line-height: 2.2rem;
-    color: #9EABB3;
+    font-family: "Open Sans", sans-serif;
 }
 
 .author-thumb {
+    float: left;
     width: 24px;
     height: 24px;
-    float: left;
-    margin-right: 9px;
     border-radius: 100%;
+    margin-right: 9px;
 }
 
 .post-meta a {
-    color: #9EABB3;
+    color: #9eabb3;
     text-decoration: none;
 }
 
@@ -989,17 +976,17 @@ body:not(.post-template) .post-title {
 
 .user-meta {
     position: relative;
-    padding: 0.3rem 40px 0 100px;
     min-height: 77px;
+    padding: 0.3rem 40px 0 100px;
 }
 
 .post-date {
     display: inline-block;
-    margin-left: 8px;
     padding-left: 12px;
-    border-left: #d5dbde 1px solid;
-    text-transform: uppercase;
+    border-left: 1px solid #d5dbde;
+    margin-left: 8px;
     font-size: 1.3rem;
+    text-transform: uppercase;
     white-space: nowrap;
 }
 
@@ -1059,8 +1046,8 @@ body:not(.post-template) .post-title {
 
 .post-template .post-date {
     padding: 0;
+    border: 0;
     margin: 0;
-    border: none;
 }
 
 /* Stop elements, such as img wider than the post content, from
@@ -1072,9 +1059,9 @@ body:not(.post-template) .post-title {
 
 /* Tweak the .post wrapper style */
 .post-template .post {
-    margin-top: 0;
-    border-bottom: none;
     padding-bottom: 0;
+    border-bottom: 0;
+    margin-top: 0;
 }
 
 /* Kill that stylish little circle that was on the border, too */
@@ -1085,19 +1072,20 @@ body:not(.post-template) .post-title {
 /* Keep images centered, and allow images wider than the main
    text column to break out. */
 .post-content img {
-    display: block;
-    max-width: 126%;
-    height: auto;
-    padding: 0.6em 0;
     /* Centers an image by (1) pushing its left edge to the
        center of its container and (2) shifting the entire image
        in the opposite direction by half its own width.
        Works for images that are larger than their containers. */
     position: relative;
     left: 50%;
+
+    display: block;
+    max-width: 126%;
+    height: auto;
+    padding: 0.6em 0;
     -webkit-transform: translateX(-50%); /* for Safari and iOS */
-    -ms-transform: translateX(-50%); /* for IE9 */
-    transform: translateX(-50%);
+        -ms-transform: translateX(-50%); /* for IE9 */
+            transform: translateX(-50%);
 }
 
 .footnotes {
@@ -1122,14 +1110,14 @@ body:not(.post-template) .post-title {
 /* The author credit area after the post */
 .post-footer {
     position: relative;
-    margin: 6rem 0 0 0;
     padding: 6rem 0 0 0;
-    border-top: #EBF2F6 1px solid;
+    border-top: 1px solid #ebf2f6;
+    margin: 6rem 0 0 0;
 }
 
 .post-footer h4 {
-    font-size: 1.8rem;
     margin: 0;
+    font-size: 1.8rem;
 }
 
 .post-footer p {
@@ -1140,17 +1128,17 @@ body:not(.post-template) .post-title {
 
 /* list of author links - location / url */
 .author-meta {
+    list-style: none;
     padding: 0;
     margin: 0;
-    list-style: none;
+    color: #9eabb3;
+    font-style: italic;
     font-size: 1.4rem;
     line-height: 1;
-    font-style: italic;
-    color: #9EABB3;
 }
 
 .author-meta a {
-    color: #9EABB3;
+    color: #9eabb3;
 }
 .author-meta a:hover {
     color: #111;
@@ -1182,10 +1170,10 @@ body:not(.post-template) .post-title {
 }
 
 .post-footer .share a {
-    font-size: 1.8rem;
     display: inline-block;
     margin: 1rem 1.6rem 1.6rem 0;
-    color: #BBC7CC;
+    color: #bbc7cc;
+    font-size: 1.8rem;
     text-decoration: none;
 }
 
@@ -1234,43 +1222,43 @@ body:not(.post-template) .post-title {
 
 .author-profile {
     padding: 0 15px 5rem 15px;
-    border-bottom: #EBF2F6 1px solid;
+    border-bottom: 1px solid #ebf2f6;
     text-align: center;
 }
 
 /* Add a little circle in the middle of the border-bottom */
 .author-profile:after {
-    display: block;
-    content: "";
-    width: 7px;
-    height: 7px;
-    border: #E7EEF2 1px solid;
     position: absolute;
     bottom: -5px;
     left: 50%;
-    margin-left: -5px;
-    background: #FFF;
+    display: block;
+    width: 7px;
+    height: 7px;
+    border: 1px solid #e7eef2;
     border-radius: 100%;
-    box-shadow: #FFF 0 0 0 5px;
+    box-shadow: 0 0 0 5px #fff;
+    margin-left: -5px;
+    background: #fff;
+    content: '';
 }
 
 .author-image {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-    display: block;
     position: absolute;
+    z-index: 2;
     top: -40px;
     left: 50%;
-    margin-left: -40px;
+    display: block;
+    -webkit-box-sizing: border-box;
+       -moz-box-sizing: border-box;
+            box-sizing: border-box;
+    overflow: hidden;
     width: 80px;
     height: 80px;
-    border-radius: 100%;
-    overflow: hidden;
     padding: 6px;
+    border-radius: 100%;
+    box-shadow: 0 0 0 1px #e7eef2;
+    margin-left: -40px;
     background: #fff;
-    z-index: 2;
-    box-shadow: #E7EEF2 0 0 0 1px;
 }
 
 .author-image .img {
@@ -1278,20 +1266,20 @@ body:not(.post-template) .post-title {
     display: block;
     width: 100%;
     height: 100%;
+    border-radius: 100%;
     background-size: cover;
     background-position: center center;
-    border-radius: 100%;
 }
 
 .author-profile .author-image {
     position: relative;
-    left: auto;
     top: auto;
+    left: auto;
     width: 120px;
     height: 120px;
     padding: 3px;
-    margin: -100px auto 0 auto;
     box-shadow: none;
+    margin: -100px auto 0 auto;
 }
 
 .author-title {
@@ -1299,10 +1287,10 @@ body:not(.post-template) .post-title {
 }
 
 .author-bio {
+    color: #50585d;
+    font-weight: 200;
     font-size: 1.8rem;
     line-height: 1.5em;
-    font-weight: 200;
-    color: #50585D;
     letter-spacing: 0;
     text-indent: 0;
 }
@@ -1313,9 +1301,9 @@ body:not(.post-template) .post-title {
 /* Location, website, and link */
 .author-profile .author-meta {
     margin: 2rem 0;
+    font-size: 1.7rem;
     font-family: "Merriweather", serif;
     letter-spacing: 0.01rem;
-    font-size: 1.7rem;
 }
 .author-meta span {
     display: inline-block;
@@ -1350,6 +1338,7 @@ body:not(.post-template) .post-title {
 }
 
 .read-next-story {
+    position: relative;
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
@@ -1358,35 +1347,34 @@ body:not(.post-template) .post-title {
     -webkit-flex-grow: 1;
     -ms-flex-positive: 1;
     flex-grow: 1;
+    overflow: hidden;
     min-width: 50%;
     text-decoration: none;
-    position: relative;
     text-align: center;
-    color: #fff;
     background: #222 no-repeat center center;
     background-size: cover;
-    overflow: hidden;
+    color: #fff;
 }
 .read-next-story:hover:before {
     background: rgba(0,0,0,0.8);
     transition: all 0.2s ease;
 }
 .read-next-story:hover .post:before {
-    color: #222;
     background: #fff;
+    color: #222;
     transition: all 0.2s ease;
 }
 
 .read-next-story:before {
-    content: "";
-    display: block;
     position: absolute;
+    display: block;
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
     background: rgba(0,0,0,0.7);
     transition: all 0.5s ease;
+    content: '';
 }
 
 .read-next-story .post {
@@ -1395,18 +1383,18 @@ body:not(.post-template) .post-title {
 }
 
 .read-next-story .post:before {
-    content: "Read This Next";
     padding: 4px 10px 5px;
-    text-transform: uppercase;
+    border: 1px solid rgba(255,255,255,0.5);
+    border-radius: 4px;
+    color: rgba(255,255,255,0.8);
     font-size: 1.1rem;
     font-family: "Open Sans", sans-serif;
-    color: rgba(255,255,255,0.8);
-    border: rgba(255,255,255,0.5) 1px solid;
-    border-radius: 4px;
+    text-transform: uppercase;
     transition: all 0.5s ease;
+    content: 'Read This Next';
 }
 .read-next-story.prev .post:before {
-    content: "You Might Enjoy";
+    content: 'You Might Enjoy';
 }
 
 .read-next-story h2 {
@@ -1429,8 +1417,8 @@ body:not(.post-template) .post-title {
 }
 
 .read-next-story.no-cover .post:before {
-    color: rgba(0,0,0,0.5);
     border-color: rgba(0,0,0,0.2);
+    color: rgba(0,0,0,0.5);
 }
 
 .read-next-story.no-cover h2 {
@@ -1443,18 +1431,18 @@ body:not(.post-template) .post-title {
 
 /* if there are two posts without covers, put a border between them */
 .read-next-story.no-cover + .read-next-story.no-cover {
-    border-left: rgba(0,0,100,0.04) 1px solid;
     -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
+       -moz-box-sizing: border-box;
+            box-sizing: border-box;
+    border-left: 1px solid rgba(0,0,100,0.04);
 }
 
 /* Correctly position site-footer when next to the .read-next container */
 .read-next + .site-footer {
     position: absolute;
+    right: 0;
     bottom: 0;
     left: 0;
-    right: 0;
     margin: 0;
 }
 
@@ -1491,14 +1479,14 @@ body:not(.post-template) .post-title {
     width: 80%;
     max-width: 710px;
     margin: 4rem auto;
-    font-family: "Open Sans", sans-serif;
+    color: #9eabb3;
     font-size: 1.3rem;
-    color: #9EABB3;
+    font-family: "Open Sans", sans-serif;
     text-align: center;
 }
 
 .pagination a {
-    color: #9EABB3;
+    color: #9eabb3;
     transition: all 0.2s ease;
 }
 
@@ -1508,9 +1496,9 @@ body:not(.post-template) .post-title {
     position: absolute;
     display: inline-block;
     padding: 0 15px;
-    border: #bfc8cd 1px solid;
-    text-decoration: none;
+    border: 1px solid #bfc8cd;
     border-radius: 4px;
+    text-decoration: none;
     transition: border 0.3s ease;
 }
 
@@ -1520,8 +1508,8 @@ body:not(.post-template) .post-title {
 
 .page-number {
     display: inline-block;
-    padding: 2px 0;
     min-width: 100px;
+    padding: 2px 0;
 }
 
 .newer-posts {
@@ -1530,27 +1518,27 @@ body:not(.post-template) .post-title {
 
 .older-posts:hover,
 .newer-posts:hover {
-    color: #889093;
     border-color: #98a0a4;
+    color: #889093;
 }
 
 .extra-pagination {
     display: none;
-    border-bottom: #EBF2F6 1px solid;
+    border-bottom: 1px solid #ebf2f6;
 }
 .extra-pagination:after {
-    display: block;
-    content: "";
-    width: 7px;
-    height: 7px;
-    border: #E7EEF2 1px solid;
     position: absolute;
     bottom: -5px;
     left: 50%;
-    margin-left: -5px;
-    background: #FFF;
+    display: block;
+    width: 7px;
+    height: 7px;
+    border: 1px solid #e7eef2;
     border-radius: 100%;
-    box-shadow: #FFF 0 0 0 5px;
+    box-shadow: 0 0 0 5px #fff;
+    margin-left: -5px;
+    background: #fff;
+    content: '';
 }
 .extra-pagination .pagination {
     width: auto;
@@ -1573,35 +1561,33 @@ body:not(.post-template) .post-title {
 
 .site-footer {
     position: relative;
-    margin: 8rem 0 0 0;
     padding: 1rem 15px;
-    font-family: "Open Sans", sans-serif;
+    margin: 8rem 0 0 0;
+    color: #bbc7cc;
     font-size: 1rem;
     line-height: 1.75em;
-    color: #BBC7CC;
+    font-family: "Open Sans", sans-serif;
 }
 
 .site-footer a {
-    color: #BBC7CC;
+    color: #bbc7cc;
+    font-weight: 700;
     text-decoration: none;
-    font-weight: bold;
 }
 
 .site-footer a:hover {
-    border-bottom: #bbc7cc 1px solid;
+    border-bottom: 1px solid #bbc7cc;
 }
 
 .poweredby {
-    display: block;
-    width: 45%;
     float: right;
+    width: 45%;
     text-align: right;
 }
 
 .copyright {
-    display: block;
-    width: 45%;
     float: left;
+    width: 45%;
 }
 
 
@@ -1617,11 +1603,11 @@ body:not(.post-template) .post-title {
 
     .main-header {
         -webkit-box-sizing: border-box;
-        -moz-box-sizing: border-box;
-        box-sizing: border-box;
+           -moz-box-sizing: border-box;
+                box-sizing: border-box;
         height: auto;
-        min-height: 240px;
         height: 60vh;
+        min-height: 240px;
         padding: 15% 0;
     }
 
@@ -1705,7 +1691,7 @@ body:not(.post-template) .post-title {
     }
 
     .post-head.main-header {
-        height:45vh;
+        height: 45vh;
     }
 
     .tag-head.main-header,
@@ -1736,8 +1722,8 @@ body:not(.post-template) .post-title {
     }
 
     .read-next-story.no-cover + .read-next-story.no-cover {
-        border-top: rgba(0,0,100,0.06) 1px solid;
-        border-left: none;
+        border-top: 1px solid rgba(0,0,100,0.06);
+        border-left: 0;
     }
 
 }
@@ -1779,15 +1765,15 @@ body:not(.post-template) .post-title {
 
     .menu-button {
         padding: 0 5px;
+        border: 0;
         border-radius: 0;
-        border-width: 0;
-        color: #2e2e2e;
         background: transparent;
+        color: #2e2e2e;
     }
     .menu-button:hover {
-        color: #2e2e2e;
         border-color: transparent;
         background: none;
+        color: #2e2e2e;
     }
     body.nav-opened .menu-button {
         background: none;
@@ -1795,16 +1781,16 @@ body:not(.post-template) .post-title {
     }
 
     .main-nav.overlay a:hover {
-        color: #fff;
         border-color: transparent;
         background: transparent;
+        color: #fff;
     }
 
     .no-cover .main-nav.overlay {
         background: none;
     }
     .no-cover .main-nav.overlay .menu-button {
-        border: none;
+        border: 0;
     }
 
     .main-nav.overlay .menu-button {
@@ -1833,11 +1819,8 @@ body:not(.post-template) .post-title {
 
     .post {
         width: auto;
-        margin-top: 2rem;
-        margin-bottom: 2rem;
-        margin-left: 16px;
-        margin-right: 16px;
         padding-bottom: 2rem;
+        margin: 2rem 16px;
         line-height: 1.65em;
     }
 
@@ -1858,8 +1841,8 @@ body:not(.post-template) .post-title {
     }
 
     p, ul, ol, dl {
-        font-size: 0.95em;
         margin: 0 0 2.5rem 0;
+        font-size: 0.95em;
     }
 
     .page-title {
@@ -1916,13 +1899,13 @@ body:not(.post-template) .post-title {
     .post-content img {
         padding: 0;
         width: calc(100% + 32px); /* expand with to image + margins */
-        min-width: 0;
         max-width: 112%; /* fallback when calc doesn't work */
+        min-width: 0;
     }
 
     .post-meta {
-        font-size: 1.3rem;
         margin-top: 1rem;
+        font-size: 1.3rem;
     }
 
     .post-footer {
@@ -1931,9 +1914,9 @@ body:not(.post-template) .post-title {
     }
 
     .post-footer .author {
-        margin: 0 0 2rem 0;
         padding: 0 0 1.6rem 0;
-        border-bottom: #EBF2F6 1px dashed;
+        border-bottom: 1px dashed #ebf2f6;
+        margin: 0 0 2rem 0;
     }
 
     .post-footer .share {
@@ -2015,24 +1998,24 @@ body:not(.post-template) .post-title {
     0% {
         opacity: 0;
         -webkit-transform: translateY(-10px);
-        transform: translateY(-10px);
+                transform: translateY(-10px);
     }
     100% {
         opacity: 1;
         -webkit-transform: translateY(0);
-        transform: translateY(0);
+                transform: translateY(0);
     }
 }
 @keyframes fade-in-down {
     0% {
         opacity: 0;
         -webkit-transform: translateY(-10px);
-        transform: translateY(-10px);
+                transform: translateY(-10px);
     }
     100% {
         opacity: 1;
         -webkit-transform: translateY(0);
-        transform: translateY(0);
+                transform: translateY(0);
     }
 }
 

--- a/author.hbs
+++ b/author.hbs
@@ -7,7 +7,7 @@
 {{#author}}
     <header class="main-header author-head {{#if cover}}" style="background-image: url({{cover}}){{else}}no-cover{{/if}}">
         <nav class="main-nav overlay clearfix">
-            {{#if @blog.logo}}<a class="blog-logo" href="{{@blog.url}}"><img src="{{@blog.logo}}" alt="{{@blog.title}}" /></a>{{/if}}
+            {{#if @blog.logo}}<a class="blog-logo" href="{{@blog.url}}"><img src="{{@blog.logo}}" alt="{{@blog.title}}"></a>{{/if}}
             {{#if @blog.navigation}}
                 <a class="menu-button icon-menu" href="#"><span class="word">Menu</span></a>
             {{/if}}
@@ -33,7 +33,7 @@
 {{/author}}
 
 {{! The main content area on the homepage }}
-<main class="content" role="main">
+<main class="content">
 
     {{! The tag below includes the post loop - partials/loop.hbs }}
     {{> "loop"}}

--- a/default.hbs
+++ b/default.hbs
@@ -2,21 +2,21 @@
 <html>
 <head>
     {{! Document Settings }}
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     {{! Page Meta }}
     <title>{{meta_title}}</title>
-    <meta name="description" content="{{meta_description}}" />
+    <meta name="description" content="{{meta_description}}">
 
-    <meta name="HandheldFriendly" content="True" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="HandheldFriendly" content="True">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link rel="shortcut icon" href="{{asset "favicon.ico"}}">
 
     {{! Styles'n'Scripts }}
-    <link rel="stylesheet" type="text/css" href="{{asset "css/screen.css"}}" />
-    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Merriweather:300,700,700italic,300italic|Open+Sans:700,400" />
+    <link rel="stylesheet" href="{{asset "css/screen.css"}}">
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Merriweather:300,700,700italic,300italic%7cOpen+Sans:700,400">
 
     {{! Ghost outputs important style and meta data with this tag }}
     {{ghost_head}}
@@ -38,13 +38,13 @@
     </div>
 
     {{!-- jQuery needs to come before `{{ghost_foot}}` so that jQuery can be used in code injection --}}
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.0/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/fitvids/1.1.0/jquery.fitvids.min.js"></script>
+    
+    {{! The main JavaScript file for Casper }}
+    <script src="{{asset "js/index.js"}}"></script>
+    
     {{! Ghost outputs important scripts and data with this tag }}
     {{ghost_foot}}
-
-    <script type="text/javascript" src="{{asset "js/jquery.fitvids.js"}}"></script>
-    {{! The main JavaScript file for Casper }}
-    <script type="text/javascript" src="{{asset "js/index.js"}}"></script>
-
 </body>
 </html>

--- a/index.hbs
+++ b/index.hbs
@@ -4,7 +4,7 @@
 {{! The big featured header }}
 <header class="main-header {{#if @blog.cover}}" style="background-image: url({{@blog.cover}}){{else}}no-cover{{/if}}">
     <nav class="main-nav overlay clearfix">
-        {{#if @blog.logo}}<a class="blog-logo" href="{{@blog.url}}"><img src="{{@blog.logo}}" alt="{{@blog.title}}" /></a>{{/if}}
+        {{#if @blog.logo}}<a class="blog-logo" href="{{@blog.url}}"><img src="{{@blog.logo}}" alt="{{@blog.title}}"></a>{{/if}}
         {{#if @blog.navigation}}
             <a class="menu-button icon-menu" href="#"><span class="word">Menu</span></a>
         {{/if}}
@@ -19,7 +19,7 @@
 </header>
 
 {{! The main content area on the homepage }}
-<main id="content" class="content" role="main">
+<main id="content" class="content">
 
     {{! The tag below includes the post loop - partials/loop.hbs }}
     {{> "loop"}}

--- a/page.hbs
+++ b/page.hbs
@@ -8,23 +8,23 @@
 
 <header class="main-header post-head {{#if image}}" style="background-image: url({{image}}){{else}}no-cover{{/if}}">
     <nav class="main-nav {{#if image}}overlay{{/if}} clearfix">
-        {{#if @blog.logo}}<a class="blog-logo" href="{{@blog.url}}"><img src="{{@blog.logo}}" alt="{{@blog.title}}" /></a>{{/if}}
+        {{#if @blog.logo}}<a class="blog-logo" href="{{@blog.url}}"><img src="{{@blog.logo}}" alt="{{@blog.title}}"></a>{{/if}}
         {{#if @blog.navigation}}
             <a class="menu-button icon-menu" href="#"><span class="word">Menu</span></a>
         {{/if}}
     </nav>
 </header>
 
-<main class="content" role="main">
+<main class="content">
     <article class="{{post_class}}">
 
         <header class="post-header">
             <h1 class="post-title">{{title}}</h1>
         </header>
 
-        <section class="post-content">
+        <div class="post-content">
             {{content}}
-        </section>
+        </div>
 
     </article>
 </main>

--- a/partials/loop.hbs
+++ b/partials/loop.hbs
@@ -9,11 +9,11 @@
     <header class="post-header">
         <h2 class="post-title"><a href="{{url}}">{{{title}}}</a></h2>
     </header>
-    <section class="post-excerpt">
+    <div class="post-excerpt">
         <p>{{excerpt words="26"}} <a class="read-more" href="{{url}}">&raquo;</a></p>
-    </section>
+    </div>
     <footer class="post-meta">
-        {{#if author.image}}<img class="author-thumb" src="{{author.image}}" alt="{{author.name}}" nopin="nopin" />{{/if}}
+        {{#if author.image}}<div class="author-thumb" style="background: url({{author.image}})" title="{{author.name}}"></div>{{/if}}
         {{author}}
         {{tags prefix=" on "}}
         <time class="post-date" datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMMM YYYY"}}</time>

--- a/post.hbs
+++ b/post.hbs
@@ -8,26 +8,26 @@
 
 <header class="main-header post-head {{#if image}}" style="background-image: url({{image}}){{else}}no-cover{{/if}}">
     <nav class="main-nav {{#if image}}overlay{{/if}} clearfix">
-        {{#if @blog.logo}}<a class="blog-logo" href="{{@blog.url}}"><img src="{{@blog.logo}}" alt="{{@blog.title}}" /></a>{{/if}}
+        {{#if @blog.logo}}<a class="blog-logo" href="{{@blog.url}}"><img src="{{@blog.logo}}" alt="{{@blog.title}}"></a>{{/if}}
         {{#if @blog.navigation}}
             <a class="menu-button icon-menu" href="#"><span class="word">Menu</span></a>
         {{/if}}
     </nav>
 </header>
 
-<main class="content" role="main">
+<main class="content">
     <article class="{{post_class}}">
 
         <header class="post-header">
             <h1 class="post-title">{{title}}</h1>
-            <section class="post-meta">
+            <div class="post-meta">
                 <time class="post-date" datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMMM YYYY"}}</time> {{tags prefix=" on "}}
-            </section>
+            </div>
         </header>
 
-        <section class="post-content">
+        <div class="post-content">
             {{content}}
-        </section>
+        </div>
 
         <footer class="post-footer">
 

--- a/tag.hbs
+++ b/tag.hbs
@@ -4,7 +4,7 @@
 {{! If we have a tag cover, display that - else blog cover - else nothing }}
 <header class="main-header tag-head {{#if tag.image}}" style="background-image: url({{tag.image}}){{else}}{{#if @blog.cover}}" style="background-image: url({{@blog.cover}}){{else}}no-cover{{/if}}{{/if}}">
     <nav class="main-nav overlay clearfix">
-        {{#if @blog.logo}}<a class="blog-logo" href="{{@blog.url}}"><img src="{{@blog.logo}}" alt="{{@blog.title}}" /></a>{{/if}}
+        {{#if @blog.logo}}<a class="blog-logo" href="{{@blog.url}}"><img src="{{@blog.logo}}" alt="{{@blog.title}}"></a>{{/if}}
         {{#if @blog.navigation}}
             <a class="menu-button icon-menu" href="#"><span class="word">Menu</span></a>
         {{/if}}
@@ -24,7 +24,7 @@
 </header>
 
 {{! The main content area on the homepage }}
-<main class="content" role="main">
+<main class="content">
 
     {{! The tag below includes the post loop - partials/loop.hbs }}
     {{> "loop"}}


### PR DESCRIPTION
# screen.css
+ Update 'normalize.css' to v3.0.3
+ Lowercase all hex color to match the general style
+ Add indent to some properties with vendor prefix to the match general style
+ Fix all value of properties related to border to match formal syntax (`<br-width> || <br-style> || <color>`)
+ Remove redundant `top: 0` from `.nav-close:after`
+ Change `bold` from `font-weight` property to `700`
+ Reorder properties, grouped by type (position, display & box model, color, text and other)

# default.hbs
+ Change illegal value `|` to `%7c` at Google Fonts link to be represented in "Normalization Form C" specification
+ Remove all closing slash on void elements
+ Remove useless `type="text/css"` and `type="text/javascript"`
+ Use CloudFlare CDN to fetch JQuery and FitVids
+ Update JQuery to v1.12.0
+ Move `{{ghost_foot}}` after all javascript that are used by default.

# author.hbs, index.hbs, page.hbs, post.hbs and tag.hbs
+ Remove closing slash on void element
+ Remove `role` property on `<main>` element
+ Changed some `<section>` to `<div>` to avoid W3C validator warning when inside miss header.

# loop.hbs
+ Change `<section class="post-excerpt">` to `<div class="post-excerpt">` to avoid W3C validator warning when the content miss header.
+ Change author thumb image display by using `<div>` with background instead `<img>` to avoid W3C validator warning with `nopin` property.