### PR TITLE
Add fallbacks to OS-provided monospace fonts

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -336,7 +336,7 @@ mark {
 
 code, tt {
     padding: 1px 3px;
-    font-family: Inconsolata, monospace, sans-serif;
+    font-family: Inconsolata, Consolas, Monaco, monospace, sans-serif;
     font-size: 0.85em;
     white-space: pre-wrap;
     border: #E3EDF3 1px solid;
@@ -354,7 +354,7 @@ pre {
     border: #E3EDF3 1px solid;
     width: 100%;
     padding: 10px;
-    font-family: Inconsolata, monospace, sans-serif;
+    font-family: Inconsolata, Consolas, Monaco, monospace, sans-serif;
     font-size: 0.9em;
     white-space: pre;
     overflow: auto;


### PR DESCRIPTION
Hi, I found `Inconsolata` is specified to `code`, `tt` and `pre`, however it is not native font for major OSs (i.e, Windows, Mac). This PR provides fallbacks to OS native monospace fonts (`Consolas` for Windows and `Monaco` for Mac), which are similar to `Inconsolata`.

`Inconsolata` is also available in Google Fonts, so I think loading it as a web font is another option, while I did not do it in this PR.