### PR TITLE
Hide home page content before animating it in

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -901,16 +901,22 @@ body.nav-opened .nav {
 
 /* Add subtle load-in animation for content on the home page */
 .home-template .page-title {
+    opacity: 0;
     -webkit-animation: fade-in-down 0.6s;
     animation: fade-in-down 0.6s;
     -webkit-animation-delay: 0.2s;
     animation-delay: 0.2s;
+    -webkit-animation-fill-mode: forwards;
+    animation-fill-mode: forwards;
 }
 .home-template .page-description {
+    opacity: 0;
     -webkit-animation: fade-in-down 0.9s;
     animation: fade-in-down 0.9s;
     -webkit-animation-delay: 0.1s;
     animation-delay: 0.1s;
+    -webkit-animation-fill-mode: forwards;
+    animation-fill-mode: forwards;
 }
 
 /* Every post, on every page, gets this style on its <article> tag */


### PR DESCRIPTION
The home page title and description are not hidden when the page is loaded, so for a split second before the CSS animation kicks in you can see both elements on the page. This makes the animation look choppy and late:

![](http://i.imgur.com/LVH2DWf.gif)

This small tweak sets the opacity of those elements to zero by default, then adds the the `forwards` fill mode to the animation so the last keyframe will stay on the page once the animation completes. This is the result:

![](http://i.imgur.com/PbXLNNB.gif)

