### PR TITLE
Fixed issue with aspect ratio of author thumbnail in posts loop

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -974,6 +974,8 @@ body:not(.post-template) .post-title {
     float: left;
     margin-right: 9px;
     border-radius: 100%;
+    background-position: center center;
+    background-size: cover;
 }
 
 .post-meta a {

--- a/partials/loop.hbs
+++ b/partials/loop.hbs
@@ -13,7 +13,7 @@
         <p>{{excerpt words="26"}} <a class="read-more" href="{{url}}">&raquo;</a></p>
     </section>
     <footer class="post-meta">
-        {{#if author.image}}<img class="author-thumb" src="{{author.image}}" alt="{{author.name}}" nopin="nopin" />{{/if}}
+        {{#if author.image}}<a class="author-thumb" style="background-image: url({{author.image}})" nopin="nopin" />{{/if}}
         {{author}}
         {{tags prefix=" on "}}
         <time class="post-date" datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMMM YYYY"}}</time>


### PR DESCRIPTION
closes #237
- changed author image in loop partial from 'img' tag to 'a' tag, with a background-image style
- changed the author-thumb CSS class to center background and set it to cover