### PR TITLE
Minor consistency fixups

### DIFF
--- a/partials/loop.hbs
+++ b/partials/loop.hbs
@@ -7,7 +7,7 @@
 {{#foreach posts}}
 <article class="{{post_class}}">
     <header class="post-header">
-        <h2 class="post-title"><a href="{{url}}">{{{title}}}</a></h2>
+        <h2 class="post-title"><a href="{{url}}">{{title}}</a></h2>
     </header>
     <section class="post-excerpt">
         <p>{{excerpt words="26"}} <a class="read-more" href="{{url}}">&raquo;</a></p>
@@ -16,7 +16,7 @@
         {{#if author.image}}<img class="author-thumb" src="{{author.image}}" alt="{{author.name}}" nopin="nopin" />{{/if}}
         {{author}}
         {{tags prefix=" on "}}
-        <time class="post-date" datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMMM YYYY"}}</time>
+        <time class="post-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="DD MMMM YYYY"}}</time>
     </footer>
 </article>
 {{/foreach}}

--- a/post.hbs
+++ b/post.hbs
@@ -21,7 +21,7 @@
         <header class="post-header">
             <h1 class="post-title">{{title}}</h1>
             <section class="post-meta">
-                <time class="post-date" datetime="{{date format='YYYY-MM-DD'}}">{{date format="DD MMMM YYYY"}}</time> {{tags prefix=" on "}}
+                <time class="post-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="DD MMMM YYYY"}}</time> {{tags prefix=" on "}}
             </section>
         </header>
 

--- a/tag.hbs
+++ b/tag.hbs
@@ -10,16 +10,18 @@
         {{/if}}
     </nav>
     <div class="vertical">
+        {{#tag}}
         <div class="main-header-content inner">
-            <h1 class="page-title">{{tag.name}}</h1>
+            <h1 class="page-title">{{name}}</h1>
             <h2 class="page-description">
-                {{#if tag.description}}
-                    {{tag.description}}
+                {{#if description}}
+                    {{description}}
                 {{else}}
-                    A {{pagination.total}}-post collection
+                    A {{../pagination.total}}-post collection
                 {{/if}}
             </h2>
         </div>
+        {{/tag}}
     </div>
 </header>
 


### PR DESCRIPTION
- use a `{{#tag}}{{/tag}}` block for tag in tag.hbs
- use two braces consistently for `{{title}}`
- use double quotes consistently for attributes (quote switching is unnecessary)