### PR TITLE
Adding prefixes to Casper

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
 <head>
     {{!-- Document Settings --}}
     <meta charset="utf-8" />


### PR DESCRIPTION
For strict "validity" we really should have these prefixes defined in the markup. Facebook, twitter and Google all seem to figure this out for themselves, but other validators like the [yandex](https://webmaster.yandex.com/microtest.xml) one show an error.

Ideally we should probably add a helper to output these instead of adding them to Casper, and I don't think it's urgent as all the sharing tools seem to work without this, just a suggestion at this point.

no issue

- This ensures that the structured data can be correctly read
- Ideally we should have a helper for this