### PR TITLE
Fixed page title and description being visible before fading in

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -976,13 +976,13 @@ body.nav-opened .nav {
 /* Add subtle load-in animation for content on the home page */
 .home-template .page-title {
     -webkit-animation: fade-in-down 0.6s;
-    animation: fade-in-down 0.6s;
+    animation: fade-in-down 0.6s both;
     -webkit-animation-delay: 0.2s;
     animation-delay: 0.2s;
 }
 .home-template .page-description {
     -webkit-animation: fade-in-down 0.9s;
-    animation: fade-in-down 0.9s;
+    animation: fade-in-down 0.9s both;
     -webkit-animation-delay: 0.1s;
     animation-delay: 0.1s;
 }


### PR DESCRIPTION
Previously, title and description were visible before the fade-in animation starts only to be hidden again and faded-in.
Adding `animation-fill-mode: both` keeps them invisible before it starts and visible afterwards.