### PR TITLE
Use protocol-relative URL for jQuery script

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -42,7 +42,7 @@
     </div>
 
     {{!-- jQuery needs to come before `{{ghost_foot}}` so that jQuery can be used in code injection --}}
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
+    <script type="text/javascript" src="//code.jquery.com/jquery-1.12.0.min.js"></script>
     {{!-- Ghost outputs important scripts and data with this tag --}}
     {{ghost_foot}}
     {{!-- Fitvids makes video embeds responsive and awesome --}}


### PR DESCRIPTION
So after a while of not using Ghost I upgraded from 0.9.0 to 0.11.2, then I noticed the menu didn't work, because for some reason "https://code.jquery.com/jquery-1.12.0.min.js" was not resolving:

![jquery-https](https://cloud.githubusercontent.com/assets/5503784/19370326/81c82ba8-9168-11e6-9f57-a8929b39f240.png)

So I tried "http://code.jquery.com/jquery-1.12.0.min.js" and it was working perfectly, same with "//code.jquery.com/jquery-1.12.0.min.js" since my blog doesn't use SSL .

I see that the link to fonts.googleapis.com is a protocol-relative URL, so it would be good to do the same with code.jquery.com?