### PR TITLE
move font above css include

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -17,8 +17,9 @@
     <link rel="shortcut icon" href="{{asset "favicon.ico"}}">
 
     {{!-- Styles'n'Scripts --}}
-    <link rel="stylesheet" type="text/css" href="{{asset "css/screen.css"}}" />
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Merriweather:300,700,700italic,300italic|Open+Sans:700,400" />
+    <link rel="stylesheet" type="text/css" href="{{asset "css/screen.css"}}" />
+
 
     {{!-- Ghost outputs important style and meta data with this tag --}}
     {{ghost_head}}


### PR DESCRIPTION
I noticed fonts are included just after the css, I think it's better to include it before to avoid FOUC.