### PR TITLE
🤖  Remove favcicon html tag

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -13,9 +13,6 @@
     <meta name="HandheldFriendly" content="True" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    {{!-- Brand icon --}}
-    <link rel="shortcut icon" href="{{asset "favicon.ico"}}">
-
     {{!-- Styles'n'Scripts --}}
     <link rel="stylesheet" type="text/css" href="{{asset "css/screen.css"}}" />
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Merriweather:300,700,700italic,300italic|Open+Sans:700,400" />


### PR DESCRIPTION
refs TryGhost/Ghost#7688

Removes `<link rel="shortcut icon" href="{{asset "favicon.ico"}}">` from `default.hbs` as it will be rendered now via `ghost_head`.