### PR TITLE
Remove explicit {{meta_description}}

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -7,7 +7,6 @@
 
     {{!-- Page Meta --}}
     <title>{{meta_title}}</title>
-    <meta name="description" content="{{meta_description}}" />
 
     {{!-- Mobile Meta --}}
     <meta name="HandheldFriendly" content="True" />


### PR DESCRIPTION
refs TryGhost/Ghost#4424

- as  of https://github.com/TryGhost/Ghost/pull/8150, `{{ghost_head}}` will output the meta description if Ghost is able to determine a sensible value to output.

Note @kevinansfield I'm not sure if we've got the alpha branch pinned to this ghost-1.0 branch of Casper? Maybe we should do an alpha release of Casper?