### PR TITLE
radio buttons and checkboxes appear regularly on chrome and safari

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -446,7 +446,11 @@ margin on the iframe, cause it breaks stuff. */
     margin: 0;
 }
 
-textarea, select, input {
+textarea, select, input[type="email"], input[type="search"],
+input[type="tel"], input[type="url"], input[type="password"],
+input[type="number"], input[type="date"], input[type="month"],
+input[type="week"], input[type="time"], input[type="datetime"],
+input[type="datetime-local"]{
     width: 260px;
     padding: 6px 9px;
     margin: 0 0 5px 0;


### PR DESCRIPTION
because  `-webkit-appearance: none;` messes with the display of radio buttons and checkboxes in chrome and safari, this styling now applies to all other input types, but not radio buttons or checkboxes.