### PR TITLE
fixed input for checkboxes and radio buttons on chrome and safari

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -446,7 +446,7 @@ margin on the iframe, cause it breaks stuff. */
     margin: 0;
 }
 
-textarea, select, input {
+textarea, select, input:not([type="radio"]):not([type="checkbox"]){
     width: 260px;
     padding: 6px 9px;
     margin: 0 0 5px 0;


### PR DESCRIPTION
closes #271

styling no longer applies to radio buttons or checkboxes, so that `-webkit-appearance: none;` does not affect their appearance in chrome and safari