### PR TITLE
✨  add default posts per page to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
             "Personal Blogs"
         ]
     },
+    "config": {
+        "posts_per_page": 5
+    },
     "keywords": [
         "ghost",
         "theme"


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/8131, refs https://github.com/TryGhost/gscan/issues/40

- we would like to show a recommendation for theme validation
- this recommendation could look like ```package.json `config.posts_per_page` is recommended. Default is 5.```
- but if we don't add the default value here, casper validation would show a warning