### PR TITLE
Allow line breaks from `Bio`

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1392,6 +1392,7 @@ body.page-template .post-title {
     color: #50585D;
     letter-spacing: 0;
     text-indent: 0;
+    white-space: pre;
 }
 
 .author-meta {


### PR DESCRIPTION
I think we should give the authors freedom to have line-breaks in their bio.
_________________________

Bio with line-break in the admin panel:
![01](https://cloud.githubusercontent.com/assets/9730242/26750163/bd8041ba-484e-11e7-8547-63a9dd0f4240.png)

Bio with line-break, without `white-space: pre;` CSS directive:
![02](https://cloud.githubusercontent.com/assets/9730242/26750165/cbc3904c-484e-11e7-9127-47307fed680a.jpg)

Bio with line-break, with `white-space: pre;` CSS directive:
![03](https://cloud.githubusercontent.com/assets/9730242/26750166/cf2ecd82-484e-11e7-8ff0-771e09d3b395.jpg)