### PR TITLE
⛓  Fix broken tag link on post.hbs

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -21,7 +21,7 @@ into the {body} of the default.hbs template --}}
                 <section class="post-full-meta">
                     <time class="post-full-meta-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="D MMMM YYYY"}}</time>
                     {{#if tags}}
-                        <span class="date-divider">/</span> <a href="{{@blog.url}}tag/{{tags.[0].slug}}">{{tags.[0].name}}</a>
+                        <span class="date-divider">/</span> <a href="{{@blog.url}}/tag/{{tags.[0].slug}}">{{tags.[0].name}}</a>
                     {{/if}}
                 </section>
                 <h1 class="post-full-title">{{title}}</h1>


### PR DESCRIPTION
no issue

Top link for tag was missing a `/`.