### PR TITLE
💄  Infinite scroll

### DIFF
--- a/assets/js/infinitescroll.js
+++ b/assets/js/infinitescroll.js
@@ -1,0 +1,18 @@
+// Code snippet inspired by https://github.com/douglasrodrigues5/ghost-blog-infinite-scroll
+$().ready(function () {
+    var page = 2,
+        blogUrl = window.location,
+        $result = $('.post-feed');
+
+    $(window).scroll(function () {
+        if ($(window).scrollTop() + $(window).height() == $(document).height()) {
+            if (page <= maxPages) {
+                $.get((blogUrl + '/page/' + page),
+                function (content) {
+                    $result.append($(content).find('.post').hide().fadeIn(100));
+                    page = page + 1;
+                });
+            }
+        }
+    });
+});

--- a/default.hbs
+++ b/default.hbs
@@ -60,7 +60,14 @@
   src="//code.jquery.com/jquery-3.2.1.slim.min.js"
   integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g="
   crossorigin="anonymous"></script>
+    {{!-- We need $ajax to make the infinite scroll work --}}
+    <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
     <script type="text/javascript" src="{{asset "js/jquery.fitvids.js"}}"></script>
+
+    <script>
+        var maxPages = parseInt('{{pagination.pages}}');
+    </script>
+    <script src="{{asset "js/infinitescroll.js"}}"></script>
 
     {{!-- The #block helper will pull in data from the #contentFor other template files. In this case, there's some JavaScript which we only want to use in post.hbs, but it needs to be included down here, after jQuery has already loaded. --}}
     {{{block "scripts"}}}

--- a/default.hbs
+++ b/default.hbs
@@ -57,11 +57,10 @@
 
     {{!-- jQuery + Fitvids, which makes all video embeds responsive --}}
     <script
-  src="//code.jquery.com/jquery-3.2.1.slim.min.js"
-  integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g="
-  crossorigin="anonymous"></script>
-    {{!-- We need $ajax to make the infinite scroll work --}}
-    <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+        src="https://code.jquery.com/jquery-3.2.1.min.js"
+        integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
+        crossorigin="anonymous">
+    </script>
     <script type="text/javascript" src="{{asset "js/jquery.fitvids.js"}}"></script>
 
     <script>


### PR DESCRIPTION
closes #314

Adds infinite scroll logic to Casper 2.0

This solution needs `$.get` which is not included in `jquery-3.2.1.slim.min.js`. Maybe there's another way to do this?

Here's a first glimpse (`config.posts_per_page` set to 6 for testing):

![infinite_scroll](https://user-images.githubusercontent.com/8037602/27373969-5b2a8a58-5694-11e7-939c-242da73e3fe8.gif)
