### PR TITLE
🎣  Infinite scroll: no API request on last page

### DIFF
--- a/assets/js/infinitescroll.js
+++ b/assets/js/infinitescroll.js
@@ -46,6 +46,11 @@ $(function ($) {
             return;
         }
 
+        // return if currentPage is the last page already
+        if (currentPage === maxPages) {
+            return;
+        }
+
         isLoading = true;
 
         // next page


### PR DESCRIPTION
no issue

Brings back a little safety guard: when the current page is also the last page, don't make an API request to the server.