### PR TITLE
Prevent floating navigation from blocking the text header in fragmented urls

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -667,6 +667,11 @@ The first (most recent) post in the list is styled to be bigger than the others 
     min-width: 100%;
 }
 
+h1, h2, h3, h4, h5, h6 {
+    padding-top: 75px;
+    margin-top: -75px;
+}
+
 .post-template .kg-card-markdown > p:first-child {
     font-size: 1.25em;
     line-height: 1.5em;

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -667,11 +667,6 @@ The first (most recent) post in the list is styled to be bigger than the others 
     min-width: 100%;
 }
 
-h1, h2, h3, h4, h5, h6 {
-    padding-top: 75px;
-    margin-top: -75px;
-}
-
 .post-template .kg-card-markdown > p:first-child {
     font-size: 1.25em;
     line-height: 1.5em;
@@ -813,6 +808,8 @@ Super neat trick courtesy of @JoelDrapper
 .post-full-content h4,
 .post-full-content h5,
 .post-full-content h6 {
+    padding-top: 75px;
+    margin-top: -75px;
     color: color(var(--darkgrey) l(-5%));
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 }


### PR DESCRIPTION
`partials/floating-header.hbs` blocks the H1-H6 header texts in fragmented urls. So, as a workaround, we will need to delegate a few space above the header.

**Without** this PR, the page would look something like this:
![image](https://user-images.githubusercontent.com/9730242/28745342-5fc02e0a-74a9-11e7-9b32-e050e5dc214b.png)

---

**With** this PR, the page would look something like this:
![image](https://user-images.githubusercontent.com/9730242/28745353-6f5fbfba-74a9-11e7-8c86-dfc659ccad22.png)
