### PR TITLE
🎨 Added specific 404 template & simplified fallback

### DIFF
--- a/error-404.hbs
+++ b/error-404.hbs
@@ -1,7 +1,6 @@
 {{!--
-This error template is used for all 400/500 errors, except 404, which might occur on your site.
+This error template is used for all 404 errors, which might occur on your site.
 It's a good idea to keep this template as minimal as possible in terms of both file size and complexity.
-You'll notice that we *don't* use any JavsScript, or ghost_head / ghost_foot in this file.
 --}}
 
 <!DOCTYPE html>
@@ -37,27 +36,21 @@ You'll notice that we *don't* use any JavsScript, or ghost_head / ghost_foot in 
                     <p class="error-description">{{message}}</p>
                     <a class="error-link" href="{{@blog.url}}">Go to the front page →</a>
                 </section>
-
-                {{#if errorDetails}}
-                <section class="error-stack">
-                    <h3>Theme errors</h3>
-                    <ul class="error-stack-list">
-                        {{#each errorDetails}}
-                            <li>
-                                <em class="error-stack-function">{{{rule}}}</em>
-
-                                {{#each failures}}
-                                    <p><span class="error-stack-file">Ref: {{ref}}</span></p>
-                                    <p><span class="error-stack-file">Message: {{message}}</span></p>
-                                {{/each}}
-                            </li>
-                        {{/each}}
-                    </ul>
-                </section>
-                {{/if}}
-
             </div>
         </main>
+
+        {{#get "posts" limit="3"}}
+        <aside class="outer">
+            <div class="inner">
+                <div class="post-feed">
+                    {{#foreach posts}}
+                        {{> "post-card"}}
+                    {{/foreach}}
+                </div>
+            </div>
+        </aside>
+        {{/get}}
+
     </div>
 </body>
 </html>


### PR DESCRIPTION
Hey @JohnONolan, I've been running into weird issues where I see lots and lots of DB requests when errors occur due to the use of the get helper on the error template. I've made some changes in Ghost that make it safer to render 404 pages, and I've made some matching changes here to differentiate.

It would also be OK to change this further, and use the default layout and/or ghost_head & ghost_foot in `error-404.hbs` as long as `error.hbs` exists and doesn't use those things.

These changes are optional but recommended, particularly as a good example.

no issue

- The 404 Error template can have a little more fancy logic than other templates
- Therefore, we make the 404 template have the get helper
- The fallback general error template has no use of the get helper
- This helps ensure that errors can be rendered