### PR TITLE
fixed z-index problem for cards on index page

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -110,7 +110,7 @@ body {
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: 10;
+    z-index: 0;
     display: block;
     background: rgba(0,0,0,0.18);
 }


### PR DESCRIPTION
z-index was causing cover image to overlap with first post card on index page. Changed z-index to 0 to fix. #349 