### PR TITLE
Author meta stack order (z-index) of hyperlinks to front

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1528,6 +1528,7 @@ Usage (In Ghost editor):
 
 .site-header-content .author-bio {
     flex-shrink: 0;
+    z-index: 10;
     max-width: 600px;
     margin: 5px 0 10px 0;
     font-size: 2rem;

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1539,6 +1539,7 @@ Usage (In Ghost editor):
 
 .site-header-content .author-meta {
     flex-shrink: 0;
+    z-index: 10;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
This PR fixes an issue where the (Social) hyperlinks in the author page can't be clicked because the hyperlinks have a low initial z-index value:
![image](https://user-images.githubusercontent.com/9730242/29481133-81c6ee1e-84b0-11e7-899d-9fdd9c6fbf8b.png)
