### PR TITLE
Remove `border-radius` in `.post-card-image-link`

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -403,7 +403,6 @@ The knock-on effect of this is ugly browser-scroll bars at the bottom, so 80px o
     position: relative;
     display: block;
     overflow: hidden;
-    border-radius: 5px 5px 0 0;
 }
 
 .post-card-image {


### PR DESCRIPTION
Setting in `.post-card-image-link` will lead to the following result:

![ghost](https://user-images.githubusercontent.com/1286674/29742081-15d0f384-8aab-11e7-9c3c-cfc56b7641ad.png)
