### PR TITLE
[HOLD] 🔥  Remove `@labs.subscribers`

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -41,7 +41,6 @@
     </div>
 
     {{!-- The big email subscribe modal content --}}
-    {{#if @labs.subscribers}}
     <div id="subscribe" class="subscribe-overlay">
         <a class="subscribe-overlay-close" href="#"></a>
         <div class="subscribe-overlay-content">
@@ -53,7 +52,6 @@
             {{subscribe_form placeholder="youremail@example.com"}}
         </div>
     </div>
-    {{/if}}
 
     {{!-- jQuery + Fitvids, which makes all video embeds responsive --}}
     <script

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "demo": "https://demo.ghost.io",
     "version": "2.1.0",
     "engines": {
-        "ghost": ">=1.2.0"
+        "ghost": ">=1.9.0"
     },
     "license": "MIT",
     "screenshots": {

--- a/partials/site-nav.hbs
+++ b/partials/site-nav.hbs
@@ -20,10 +20,6 @@
                 <a class="social-link social-link-tw" href="{{twitter_url @blog.twitter}}" target="_blank">{{> "icons/twitter"}}</a>
             {{/if}}
         </div>
-        {{#if @labs.subscribers}}
-            <a class="subscribe-button" href="#subscribe">Subscribe</a>
-        {{else}}
-            <a class="rss-button" href="http://cloud.feedly.com/#subscription/feed/{{@blog.url}}/rss/" target="_blank">{{> "icons/rss"}}</a>
-        {{/if}}
+        <a class="subscribe-button" href="#subscribe">Subscribe</a>
     </div>
 </nav>

--- a/post.hbs
+++ b/post.hbs
@@ -37,13 +37,11 @@ into the {body} of the default.hbs template --}}
             </section>
 
             {{!-- Email subscribe form at the bottom of the page --}}
-            {{#if @labs.subscribers}}
             <section class="subscribe-form">
                 <h3 class="subscribe-form-title">Subscribe to {{@blog.title}}</h3>
                 <p>Get the latest posts delivered right to your inbox</p>
                 {{subscribe_form placeholder="youremail@example.com"}}
             </section>
-            {{/if}}
 
             <footer class="post-full-footer">
                 {{!-- Everything inside the #author tags pulls data from the author --}}


### PR DESCRIPTION
no issue

Will be compatible with Ghost 1.9.

In Ghost 1.9 we enabled subscribers by default.
NOTE: `@labs.subscribers` is still available for themes to avoid breaking them.

Bump Ghost engine, because if you are using this version of casper < Ghost 1.9, you would not be able to disable the subscribers feature.

**I would wait with merging, because 1.9 will be released on Thursday and if there are any patch changes, we would have to revert this PR! That's why the PR is HOLD!**