### PR TITLE
Fix typo

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -14,7 +14,7 @@
     {{!-- Styles'n'Scripts --}}
     <link rel="stylesheet" type="text/css" href="{{asset "built/screen.css"}}" />
 
-    {{!-- This tag outputes SEO meta+structured data and other important settings --}}
+    {{!-- This tag outputs SEO meta+structured data and other important settings --}}
     {{ghost_head}}
 
 </head>


### PR DESCRIPTION
This PR fixes a small typo in the Handlebars template in `default.hbs`.