### PR TITLE
Optimize gulp zip file generation.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,12 @@ gulp.task('zip', ['css'], function() {
     var themeName = require('./package.json').name;
     var filename = themeName + '.zip';
 
-    return gulp.src(['**', '!node_modules', '!node_modules/**'])
+    return gulp.src([
+        '**',
+        '!node_modules', '!node_modules/**',
+        '!dist', '!dist/**',
+        '!assets/css', '!assets/css/**',
+    ])
         .pipe(zip(filename))
         .pipe(gulp.dest(targetDir));
 });


### PR DESCRIPTION
I realized that `gulp zip` task contains two useless folders for production mode: `dist` and `css` folders.

- `dist` is not required because it contains the zip file itself.
- `css` is not required because template file uses `built` folder to get styles.

So I think it's better to strip out those folders to reduce zip size.