### PR TITLE
Remove gulpfile & css in the dist file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,6 +58,8 @@ gulp.task('zip', ['css'], function() {
 
     return gulp.src([
         '**',
+        '!gulpfile.js',
+        '!assets/css', '!assets/css/**',
         '!node_modules', '!node_modules/**',
         '!dist', '!dist/**'
     ])


### PR DESCRIPTION
These files should not appear in the dist, because they can be accessed by the user.

> e.g.
> https://demo.ghost.io/gulpfile.js
> https://demo.ghost.io/assets/css/screen.css

But it's not necessary.

https://github.com/TryGhost/Ghost/blob/master/core/server/web/middleware/static-theme.js#L9