### PR TITLE
Update Feedly URL and to HTTPS protocol

### DIFF
--- a/author.hbs
+++ b/author.hbs
@@ -30,7 +30,7 @@
                 {{#if facebook}}
                     <a class="social-link social-link-fb" href="{{facebook_url}}" target="_blank" rel="noopener">{{> "icons/facebook"}}</a>
                 {{/if}}
-                <a class="social-link social-link-rss" href="http://cloud.feedly.com/#subscription/feed/{{url absolute="true"}}/rss/" target="_blank" rel="noopener">{{> "icons/rss"}}</a>
+                <a class="social-link social-link-rss" href="https://cloud.feedly.com/#subscription/feed/{{url absolute="true"}}/rss/" target="_blank" rel="noopener">{{> "icons/rss"}}</a>
             </div>
         </div>
     </div>

--- a/author.hbs
+++ b/author.hbs
@@ -30,7 +30,7 @@
                 {{#if facebook}}
                     <a class="social-link social-link-fb" href="{{facebook_url}}" target="_blank" rel="noopener">{{> "icons/facebook"}}</a>
                 {{/if}}
-                <a class="social-link social-link-rss" href="https://cloud.feedly.com/#subscription/feed/{{url absolute="true"}}/rss/" target="_blank" rel="noopener">{{> "icons/rss"}}</a>
+                <a class="social-link social-link-rss" href="https://feedly.com/i/subscription/feed/{{url absolute="true"}}/rss/" target="_blank" rel="noopener">{{> "icons/rss"}}</a>
             </div>
         </div>
     </div>

--- a/partials/site-nav.hbs
+++ b/partials/site-nav.hbs
@@ -23,7 +23,7 @@
         {{#if @labs.subscribers}}
             <a class="subscribe-button" href="#subscribe">Subscribe</a>
         {{else}}
-            <a class="rss-button" href="https://cloud.feedly.com/#subscription/feed/{{@blog.url}}/rss/" target="_blank" rel="noopener">{{> "icons/rss"}}</a>
+            <a class="rss-button" href="https://feedly.com/i/subscription/feed/{{@blog.url}}/rss/" target="_blank" rel="noopener">{{> "icons/rss"}}</a>
         {{/if}}
     </div>
 </nav>

--- a/partials/site-nav.hbs
+++ b/partials/site-nav.hbs
@@ -23,7 +23,7 @@
         {{#if @labs.subscribers}}
             <a class="subscribe-button" href="#subscribe">Subscribe</a>
         {{else}}
-            <a class="rss-button" href="http://cloud.feedly.com/#subscription/feed/{{@blog.url}}/rss/" target="_blank" rel="noopener">{{> "icons/rss"}}</a>
+            <a class="rss-button" href="https://cloud.feedly.com/#subscription/feed/{{@blog.url}}/rss/" target="_blank" rel="noopener">{{> "icons/rss"}}</a>
         {{/if}}
     </div>
 </nav>


### PR DESCRIPTION
Hi,

Given that the [W3C Link Checker](https://validator.w3.org/checklink) marks the current URL of using Feedly as a permanent redirect (HTTP 301) it should be relevant to update the anchor sources accordingly in the default template, too.

Line: 120 http://cloud.feedly.com/ redirected to https://cloud.feedly.com/
Status: 301 -> 200 OK
This is a permanent redirect. The link should be updated to point to the more recent URI.

Broken fragments:
http://cloud.feedly.com/#subscription/feed/https://jochen.kirstaetter.name/rss/ (line 120)

Thanks for consideration.

Regards, Jochen
  