### PR TITLE
Only show Twitter/FB if they are populated

### DIFF
--- a/partials/floating-header.hbs
+++ b/partials/floating-header.hbs
@@ -11,14 +11,18 @@
     <div class="floating-header-title">{{title}}</div>
     <div class="floating-header-share">
         <div class="floating-header-share-label">Share this {{> "icons/point"}}</div>
+        {{#if @blog.twitter}}
         <a class="floating-header-share-tw" href="https://twitter.com/share?text={{encode title}}&amp;url={{url absolute="true"}}"
             onclick="window.open(this.href, 'share-twitter', 'width=550,height=235');return false;">
             {{> "icons/twitter"}}
         </a>
+        {{/if}}
+        {{#if @blog.facebook}}
         <a class="floating-header-share-fb" href="https://www.facebook.com/sharer/sharer.php?u={{url absolute="true"}}"
             onclick="window.open(this.href, 'share-facebook','width=580,height=296');return false;">
             {{> "icons/facebook"}}
         </a>
+        {{/if}}
     </div>
     <progress class="progress" value="0">
         <div class="progress-container">


### PR DESCRIPTION
The floating header was showing the Facebook and Twitter social sharing icons even if the blog did not populate those fields in settings.

This PR adds the necessary conditionals to only show the sharing options which exist.