### PR TITLE
Display theme's layout to the full size of iPhone X's screen

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -9,7 +9,7 @@
     {{!-- Base Meta --}}
     <title>{{meta_title}}</title>
     <meta name="HandheldFriendly" content="True" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
     {{!-- Styles'n'Scripts --}}
     <link rel="stylesheet" type="text/css" href="{{asset "built/screen.css"}}" />


### PR DESCRIPTION
Hi,

WebKit's default value of `viewport-fit` is `auto`, which results in the automatic insetting behavior in WebKit-based browsers. To make the Casper theme's layout utilize the full size of the iPhone X's screen, this PR adds the `viewport-fit=cover` in `viewport` meta tag.

You can see this change working on iPhone X when viewing my own site, http://karloespiritu.com, when using iPhone X, which uses a modified version of the Casper theme.

A more detailed explanation can be seen here: [https://webkit.org/blog/7929/designing-websites-for-iphone-x/](https://webkit.org/blog/7929/designing-websites-for-iphone-x/)

Thanks.

