### PR TITLE
Fix Feedly URL

### DIFF
--- a/author.hbs
+++ b/author.hbs
@@ -30,7 +30,7 @@
                 {{#if facebook}}
                     <a class="social-link social-link-fb" href="{{facebook_url}}" target="_blank" rel="noopener">{{> "icons/facebook"}}</a>
                 {{/if}}
-                <a class="social-link social-link-rss" href="http://cloud.feedly.com/#subscription/feed/{{url absolute="true"}}/rss/" target="_blank" rel="noopener">{{> "icons/rss"}}</a>
+                <a class="social-link social-link-rss" href="https://feedly.com/i/subscription/feed/{{url absolute="true"}}/rss/" target="_blank" rel="noopener">{{> "icons/rss"}}</a>
             </div>
         </div>
     </div>

--- a/partials/site-nav.hbs
+++ b/partials/site-nav.hbs
@@ -23,7 +23,7 @@
         {{#if @labs.subscribers}}
             <a class="subscribe-button" href="#subscribe">Subscribe</a>
         {{else}}
-            <a class="rss-button" href="http://cloud.feedly.com/#subscription/feed/{{@blog.url}}/rss/" target="_blank" rel="noopener">{{> "icons/rss"}}</a>
+            <a class="rss-button" href="https://feedly.com/i/subscription/feed/{{@blog.url}}/rss/" target="_blank" rel="noopener">{{> "icons/rss"}}</a>
         {{/if}}
     </div>
 </nav>


### PR DESCRIPTION
The existing URL returns a 404. The new URL is based on:

https://feedly.uservoice.com/knowledgebase/articles/187494-how-to-add-news-feeds-to-your-feedly

The broken link was pointed out to me on my blog:

http://cloud.feedly.com/#subscription/feed/https://www.pgrs.net/rss/

But this one works:

https://feedly.com/i/subscription/feed/https://www.pgrs.net/rss/