### PR TITLE
Fix scrolling of site nav

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -208,7 +208,6 @@ body {
     overflow-y: hidden;
     -webkit-overflow-scrolling: touch;
     margin-right: 10px;
-    padding-bottom: 80px;
     letter-spacing: 0.4px;
     white-space: nowrap;
 


### PR DESCRIPTION
While modifying the casper theme, my site navigation suddenly disappeared when I was scrolling up/down the page.

Example can be found here: https://demo.ghost.io/

![casp](https://user-images.githubusercontent.com/795665/37064469-5c70a35a-219d-11e8-9bde-2d1d91479fd5.gif)
