### PR TITLE
Append blog title to post titles to improve SEO

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -7,7 +7,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     {{!-- Base Meta --}}
-    <title>{{meta_title}}</title>
+    <title>
+        {{#is "post, page"}}
+        {{meta_title}} - {{@blog.title}}
+        {{else}}
+        {{meta_title}}
+        {{/is}}
+    </title>
     <meta name="HandheldFriendly" content="True" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 


### PR DESCRIPTION
It's often recommended to include the site name in the title of a page for better SEO.

This patch will do so by default for posts and pages.