### PR TITLE
fixed how authors show on post preview

### DIFF
--- a/partials/byline-single.hbs
+++ b/partials/byline-single.hbs
@@ -1,5 +1,5 @@
 {{!-- Everything inside the #author tags pulls data from the author --}}
-{{#foreach authors}}
+{{#primary_author}}
 
 <section class="author-card">
     {{#if profile_image}}
@@ -20,4 +20,4 @@
     <a class="author-card-button" href="{{url}}">Read More</a>
 </div>
 
-{{/foreach}}
+{{/primary_author}}

--- a/partials/byline-single.hbs
+++ b/partials/byline-single.hbs
@@ -1,5 +1,5 @@
 {{!-- Everything inside the #author tags pulls data from the author --}}
-{{#author}}
+{{#foreach authors}}
 
 <section class="author-card">
     {{#if profile_image}}
@@ -20,4 +20,4 @@
     <a class="author-card-button" href="{{url}}">Read More</a>
 </div>
 
-{{/author}}
+{{/foreach}}


### PR DESCRIPTION
fixes [#9598](https://github.com/TryGhost/Ghost/issues/9598)

The handlebar being used for posts with a single author was using the author helper. This was causing an issue when previewing a post as it wasn’t showing any author info. I’ve changed this to use authors.