### PR TITLE
Fix for missing default avatar and firefox footer misalignment

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -462,7 +462,8 @@ The knock-on effect of this is ugly browser-scroll bars at the bottom, so 80px o
     padding: 0 25px 25px;
 }
 
-.author-profile-image {
+.author-profile-image,
+.avatar-wrapper {
     display: block;
     background: color(var(--lightgrey) l(+10%));
     border-radius: 100%;
@@ -1271,7 +1272,8 @@ Usage (In Ghost editor):
     display: flex;
 }
 
-.author-card .author-profile-image {
+.author-card .author-profile-image,
+.author-card .avatar-wrapper {
     margin-right: 15px;
     width: 60px;
     height: 60px;


### PR DESCRIPTION
Fixes #457 
- Added base css for avatar-wrapper to reflect the same characteristics of author-profile-image.
- Added css to the avatar image in the post footer, so that it matches the dimensions of the author-profile-image and doesn't collapse and disappear (like in Chrome) or expand (like in Firefox).

RESULT:
### **Chrome** - Single Author with no Profile Image Set (Fixed: Missing avatar_)
<img width="956" alt="screen shot 2018-05-23 at 3 02 53 pm" src="https://user-images.githubusercontent.com/2308001/40416264-7c230a3c-5e9a-11e8-9c27-bbd1d984adf3.png">

---

### **Firefox** - Single Author with no Profile Image Set (Fixed: Missing avatar and Misaligned_)
<img width="954" alt="screen shot 2018-05-23 at 3 03 27 pm" src="https://user-images.githubusercontent.com/2308001/40416265-7c89f5bc-5e9a-11e8-81aa-11b851e92c5e.png">
