### PR TITLE
[Fix] Force tables to break line when long content is present

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1103,7 +1103,6 @@ Usage (In Ghost editor):
     border-collapse: collapse;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
     font-size: 1.6rem;
-    white-space: nowrap;
     vertical-align: top;
 }
 


### PR DESCRIPTION
I'm not sure if it's an issue or not but this refers to #469 