### PR TITLE
[Fix] Inline <code> tag word-break inside a <p> tag

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -915,6 +915,10 @@ Usage (In Ghost editor):
     border-radius: 3px;
 }
 
+.post-full-content p code {
+    word-break: break-all;
+}
+
 .post-full-content pre {
     overflow-x: auto;
     margin: 1.5em 0 3em;


### PR DESCRIPTION
Fixing #466

PR to force word-break an inline `code` tag inside a paragraph.