### PR TITLE
Remove css rule that stops syntax highlighting 

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -935,10 +935,6 @@ Usage (In Ghost editor):
     background: transparent;
 }
 
-.post-full-content pre code * {
-    color: inherit;
-}
-
 .post-full-content .fluid-width-video-wrapper {
     margin: 1.5em 0 3em;
 }

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -935,6 +935,11 @@ Usage (In Ghost editor):
     background: transparent;
 }
 
+.post-full-content pre code :not(span) {
+    color: inherit;
+}
+
+
 .post-full-content .fluid-width-video-wrapper {
     margin: 1.5em 0 3em;
 }

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -939,7 +939,6 @@ Usage (In Ghost editor):
     color: inherit;
 }
 
-
 .post-full-content .fluid-width-video-wrapper {
     margin: 1.5em 0 3em;
 }


### PR DESCRIPTION
Removed the ".post-full-content pre code * { color: inherit }" rule which prevents highlight.js from working.

I don't think this breaks anything, please correct me if I am wrong.