### PR TITLE
Use a larger logo size

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -7,7 +7,7 @@ into the {body} of the default.hbs template --}}
         <div class="site-header-content">
             <h1 class="site-title">
                 {{#if @site.logo}}
-                    <img class="site-logo" src="{{img_url @site.logo size="s"}}" alt="{{@site.title}}" />
+                    <img class="site-logo" src="{{img_url @site.logo size="l"}}" alt="{{@site.title}}" />
                 {{else}}
                     {{@site.title}}
                 {{/if}}


### PR DESCRIPTION
Before this change, logos used to display in the size that they were uploaded. Now, the theme uses a 300w logo, which is rather small, especially on high-resolution screens. With Ghost(Pro), you cannot change this setting dynamically, either. You can, however, always upload a smaller logo or downsize a logo with CSS, but you cannot upscale a logo without pixelation. For that reason, I believe it's best to load a larger size.