### PR TITLE
Fix zipping on new Node.js version compatibility

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2970,8 +2970,8 @@ nanomatch@^1.2.9:
     to-regex "^3.0.1"
 
 natives@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.3.tgz#44a579be64507ea2d6ed1ca04a9415915cf75558"
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
 
 nconf@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
Running `yarn zip` on Node.js v10.15.1 doesn't work due to https://github.com/gulpjs/gulp/issues/2246:

```
$ node --version
v10.15.1

$ yarn
yarn install v1.13.0
[1/5] 🔍  Validating package.json...
warning casper@2.9.2: The engine "ghost" appears to be invalid.
warning casper@2.9.2: The engine "ghost-api" appears to be invalid.
[2/5] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.40s.

$ yarn zip
yarn run v1.13.0
$ gulp zip
internal/util/inspect.js:31
const types = internalBinding('types');
              ^

ReferenceError: internalBinding is not defined
    at internal/util/inspect.js:31:15
    at req_ (/tmp/Casper/node_modules/natives/index.js:137:5)
    at require (/tmp/Casper/node_modules/natives/index.js:110:12)
    at util.js:25:21
    at req_ (/tmp/Casper/node_modules/natives/index.js:137:5)
    at require (/tmp/Casper/node_modules/natives/index.js:110:12)
    at fs.js:42:21
    at req_ (/tmp/Casper/node_modules/natives/index.js:137:5)
    at Object.req [as require] (/tmp/Casper/node_modules/natives/index.js:54:10)
    at Object.<anonymous> (/tmp/Casper/node_modules/vinyl-fs/node_modules/graceful-fs/fs.js:1:99)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```