### PR TITLE
Delete "height" from .author-card .avatar-wrapper

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1295,7 +1295,6 @@ Usage (In Ghost editor):
 .author-card .avatar-wrapper {
     margin-right: 15px;
     width: 60px;
-    height: 60px;
 }
 
 .author-card-name {


### PR DESCRIPTION
The fixed height led to an issue which appears on resizing the window, especially on smartphones. The Icon would not be a real circle, this gets resolved by remove the fixed height from CSS.