### PR TITLE
Updated current version and previous version logic

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ const postcss = require('gulp-postcss');
 const zip = require('gulp-zip');
 const uglify = require('gulp-uglify');
 const beeper = require('beeper');
+const fs = require('fs');
 
 // postcss plugins
 const autoprefixer = require('autoprefixer');
@@ -121,9 +122,9 @@ const previousRelease = () => {
                 console.log('No releases found. Skipping');
                 return;
             }
-
-            console.log(`Previous version ${response[0].name}`);
-            return response[0].name;
+            let prevVersion = response[0].tag_name || response[0].name;
+            console.log(`Previous version ${prevVersion}`);
+            return prevVersion;
         });
 };
 
@@ -143,7 +144,9 @@ const previousRelease = () => {
  */
 const release = () => {
     // @NOTE: https://yarnpkg.com/lang/en/docs/cli/version/
-    const newVersion = process.env.npm_package_version;
+    // require(./package.json) can run into caching issues, this re-reads from file everytime on release
+    var packageJSON = JSON.parse(fs.readFileSync('./package.json'));
+    const newVersion = packageJSON.version;
     let shipsWithGhost = '{version}';
     let compatibleWithGhost = '2.10.0';
     const ghostEnvValues = process.env.GHOST || null;


### PR DESCRIPTION
no issue

- Use current version from `package.json` instead of `npm_package_version` env variable
- Use `release.tag_name` instead of `release.name` for previous version