### PR TITLE
fixing contrast ratio for "midgrey" text

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -10,6 +10,7 @@
     --red: #f05230;
     --darkgrey: #15171A;
     --midgrey: #738a94;
+    --midgrey-text: #4a5b62;
     --lightgrey: #c5d2d9;
     --whitegrey: #e5eff5;
     --pink: #fa3a57;

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -432,7 +432,7 @@ The knock-on effect of this is ugly browser-scroll bars at the bottom, so 80px o
 .post-card-tags {
     display: block;
     margin-bottom: 4px;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 1.2rem;
     line-height: 1.15em;
     font-weight: 500;
@@ -585,7 +585,7 @@ The knock-on effect of this is ugly browser-scroll bars at the bottom, so 80px o
 .reading-time {
     flex-shrink: 0;
     margin-left: 20px;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 1.2rem;
     line-height: 33px;
     font-weight: 500;
@@ -689,7 +689,7 @@ make sure this only happens on large viewports / desktop-ish devices.
     display: flex;
     justify-content: center;
     align-items: center;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 1.4rem;
     font-weight: 600;
     text-transform: uppercase;
@@ -1181,7 +1181,7 @@ Usage (In Ghost editor):
 
 .subscribe-form p {
     margin-bottom: 1em;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 2.2rem;
     line-height: 1.55em;
     letter-spacing: 0.2px;
@@ -1204,7 +1204,7 @@ Usage (In Ghost editor):
     padding: 10px;
     width: 100%;
     border: color(var(--lightgrey) l(+7%)) 1px solid;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 1.8rem;
     line-height: 1em;
     font-weight: normal;
@@ -1315,7 +1315,7 @@ Usage (In Ghost editor):
 
 .author-card-content p {
     margin: 0;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     line-height: 1.3em;
 }
 
@@ -1328,7 +1328,7 @@ Usage (In Ghost editor):
     display: block;
     padding: 9px 16px;
     border: color(var(--midgrey) l(+20%)) 1px solid;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 1.2rem;
     line-height: 1;
     font-weight: 500;
@@ -1361,7 +1361,7 @@ Usage (In Ghost editor):
 
 .post-full-authors-content p {
     margin-bottom: 0;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 1.4rem;
     letter-spacing: 0.2px;
     text-align: center;
@@ -2031,7 +2031,7 @@ Usage (In Ghost editor):
 
 .error-description {
     margin: 0;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 3rem;
     line-height: 1.3em;
     font-weight: 400;
@@ -2130,7 +2130,7 @@ Usage (In Ghost editor):
     padding: 14px 20px;
     width: 100%;
     border: none;
-    color: var(--midgrey);
+    color: var(--midgrey-text);
     font-size: 2rem;
     line-height: 1em;
     font-weight: normal;


### PR DESCRIPTION
When running a Chrome accessibility audit it said that the text on the "reading time" in a post-card was not high enough. It looks like it gets a score of 3.63: 

<img width="256" alt="Screenshot 2019-04-22 at 09 29 44" src="https://user-images.githubusercontent.com/594890/56491659-31f3ef00-64e1-11e9-9544-c22d21da6ca3.png">

This change adds in a `--midgrey-text` variable that should be used in place of `--midgrey` for anything that is on text. The value I chose was literally just dragging the colour picker straight down until it passed the AAA contrast ratio line: 

<img width="253" alt="Screenshot 2019-04-22 at 09 31 46" src="https://user-images.githubusercontent.com/594890/56491748-797a7b00-64e1-11e9-980b-c4d49a4727fe.png">

If you feel like this doesn't live up to the design I think we should at least pass the A test for contrast ratio, but if it's not too far off we should consider passing the AAA test if we can 👍 

Let me know if you have any questions