### PR TITLE
1.4 branch: fix image caption not being centered

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -62,6 +62,7 @@ sub { bottom: -0.25em; }
 img { border: 0; }
 svg:not(:root) { overflow: hidden; }
 figure { margin: 1em 40px; }
+figcaption { text-align: center; }
 hr { box-sizing: content-box; height: 0; }
 pre { overflow: auto; }
 code, kbd, pre, samp { font-family: monospace, monospace; font-size: 1em; }


### PR DESCRIPTION
On Mac Firefox 66 (and I'm sure many other browsers), image captions on Casper 1.5.0 are not correctly centered. This small CSS change fixes this.

**Before:**

<img width="738" alt="image" src="https://user-images.githubusercontent.com/1213121/56942030-7b84af80-6b5b-11e9-86ca-8017f49daf29.png">

**After:**

<img width="758" alt="image" src="https://user-images.githubusercontent.com/1213121/56942022-6b6cd000-6b5b-11e9-91f6-4ff3495cbe6c.png">
