### PR TITLE
Update jQuery cdn

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -69,7 +69,7 @@
 
     {{!-- jQuery + Fitvids, which makes all video embeds responsive --}}
     <script
-        src="https://code.jquery.com/jquery-3.2.1.min.js"
+        src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"
         integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
         crossorigin="anonymous">
     </script>


### PR DESCRIPTION
Updated jQuery source url from code.jquery.com to cdnjs for better loading speed of websites.