### PR TITLE
Fix Safari render/paint loop

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -387,20 +387,51 @@ The knock-on effect of this is ugly browser-scroll bars at the bottom, so 80px o
     flex: 1 1 300px;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    overflow: visible;
     margin: 0 20px 40px;
     min-height: 300px;
     background: #fff center center;
     background-size: cover;
     border-radius: 5px;
-    box-shadow: rgba(39,44,49,0.06) 8px 14px 38px, rgba(39, 44, 49, 0.03) 1px 3px 8px;
     transition: all 0.5s ease;
+    z-index: 1;
+    position: relative;
 }
 
 .post-card:hover {
-    box-shadow: rgba(39,44,49,0.07) 8px 28px 50px, rgba(39, 44, 49, 0.04) 1px 6px 12px;
     transition: all 0.4s ease;
     transform: translate3D(0, -1px, 0) scale(1.02);
+}
+
+.post-card:before, .post-card:after {
+    display: block;
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 0;
+    transition: all 0.4s ease;
+    border-radius: 5px;
+}
+
+.post-card:before {
+    opacity: 1;
+    box-shadow: rgba(39,44,49,0.06) 8px 14px 38px, rgba(39, 44, 49, 0.03) 1px 3px 8px;
+}
+
+.post-card:after {
+    opacity: 0;
+    box-shadow: rgba(39,44,49,0.07) 8px 28px 50px, rgba(39, 44, 49, 0.04) 1px 6px 12px;
+}
+
+.post-card:hover:before {
+    opacity: 0;
+}
+
+.post-card:hover:after {
+    opacity: 1;
 }
 
 .post-card-image-link {
@@ -408,6 +439,7 @@ The knock-on effect of this is ugly browser-scroll bars at the bottom, so 80px o
     display: block;
     overflow: hidden;
     border-radius: 5px 5px 0 0;
+    z-index: 1;
 }
 
 .post-card-image {
@@ -423,6 +455,7 @@ The knock-on effect of this is ugly browser-scroll bars at the bottom, so 80px o
     display: block;
     padding: 25px 25px 0;
     color: var(--darkgrey);
+    z-index: 1;
 }
 
 .post-card-content-link:hover {


### PR DESCRIPTION
Fix Safari render/paint loop

**What:**

As identified in [this bug
report](https://bugs.webkit.org/show_bug.cgi?id=194332) with additional
comments clarifying my findings hopefully soon to appear, there is a bug
in Safari that starts and endless cycle of render/paints when all the
following conditions are met:

1. a `transition` animation is defined that is not instantaneous
2. In the destination of the transition, an animating property contains
   a color value with:
  a) an alpha channel that is *exclusively* between 0 and 1
  b) at least one color channel which is *exclusively* between 0 and 255

These conditions represent my current best guess at the exact
requirements to encounter this bug.

You can explore the bug in this fiddle I made while trying to pinpoint
the minimum reproduction: https://jsfiddle.net/0ph9xkrt/7/

The bug described above affects this template only on the `.post-card`
class. All other animations (that I am aware of and have tested)
involving an element with an `rgba` color in one of its properties do
not directly animate the property containing the color, and are thus not
triggering this bug.

**How:**

There are three ways we can avoid the bug for the hover animation of
`.post-card`s in this template. One, we could just alter the shadow's
color to be a pure black (nullifying condition 2.b) and then compensate
the darker color with a slightly more transparent alpha channel. Two, we
could use the actual design colors (which actually contain a hint of
color) but skip animating the distance/blur of the shadow which means we
do not have to animate a property containing the color (nullifying
condition 2). Or three, we can use pseudo-selectors to define `:before`
and `:after` with each representing one state for the box shadow, then
animate only the opacity between the two (also nullifying condition 2).

This third option was the choice here since it will keep the design of
the site as is, visually, without compromising the color of the shadow
or the changable size of the shadow. It does have one drawback that the
other two options do not: the css is much more complex, as you'll see in
the diff. Not only do we need to add all the different states for two
new pseudo-selectors, but we also need to ensure that the links under
them are set to have a higher z-index so they remain clickable.