### PR TITLE
Fix text descenders from being cut off

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1665,7 +1665,7 @@ Usage (In Ghost editor):
     display: flex;
     align-items: center;
     color: var(--darkgrey);
-    line-height: 1.1em;
+    line-height: normal;
     font-weight: 700;
 }
 


### PR DESCRIPTION
Changing the line-height to normal (which is the default line-height) so that the user agent uses a "reasonable" value based on the font of the element according to the spec: https://www.w3.org/TR/CSS2/visudet.html#propdef-line-height