### PR TITLE
Fixes background color issue with post-card image rounded corner

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -390,7 +390,7 @@ The knock-on effect of this is ugly browser-scroll bars at the bottom, so 80px o
     overflow: hidden;
     margin: 0 20px 40px;
     min-height: 300px;
-    background: #fff center center;
+    background: transparent center center;
     background-size: cover;
     border-radius: 5px;
     box-shadow: rgba(39,44,49,0.06) 8px 14px 38px, rgba(39, 44, 49, 0.03) 1px 3px 8px;
@@ -445,6 +445,7 @@ The knock-on effect of this is ugly browser-scroll bars at the bottom, so 80px o
 }
 
 .post-card-content {
+    background-color: #fff;
     flex-grow: 1;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
This PR fixes an issue I noticed where there is a small amount of white background being rendered on the top left `.post-card` rounded corner.

For example (you might need to zoom in a little).

<img width="87" alt="Screenshot 2019-09-03 at 19 43 34" src="https://user-images.githubusercontent.com/4869877/64199859-2ba85300-ce83-11e9-941b-30be13d19f4e.png">

Moving the background-color onto the `. post-card-content` class solves this issue.
