### PR TITLE
Changed {{code}} to {{statusCode}}

### DIFF
--- a/error-404.hbs
+++ b/error-404.hbs
@@ -32,7 +32,7 @@ It's a good idea to keep this template as minimal as possible in terms of both f
             <div class="inner">
 
                 <section class="error-message">
-                    <h1 class="error-code">{{code}}</h1>
+                    <h1 class="error-code">{{statusCode}}</h1>
                     <p class="error-description">{{message}}</p>
                     <a class="error-link" href="{{@site.url}}">Go to the front page →</a>
                 </section>

--- a/error.hbs
+++ b/error.hbs
@@ -33,7 +33,7 @@ You'll notice that we *don't* use any JavsScript, or ghost_head / ghost_foot in 
             <div class="inner">
 
                 <section class="error-message">
-                    <h1 class="error-code">{{code}}</h1>
+                    <h1 class="error-code">{{statusCode}}</h1>
                     <p class="error-description">{{message}}</p>
                     <a class="error-link" href="{{@site.url}}">Go to the front page →</a>
                 </section>


### PR DESCRIPTION
refs https://github.com/TryGhost/gscan/commit/2ebd9feeee20c084a1d4ab84e5100cdb1e1400de

- {{code}} use has been deprecated in canary rule set of gscan

TODO:
- [x] do a real world test with theme with these changes