### PR TITLE
Fixing image bug for link preview

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -2232,7 +2232,7 @@ Usage (In Ghost editor):
     position: absolute;
     top: 0;
     left: 0;
-    width: 100%;
+    width: auto;
     height: 100%;
     border-radius: 0 3px 3px 0;
 

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -2232,11 +2232,11 @@ Usage (In Ghost editor):
     position: absolute;
     top: 0;
     left: 0;
-    width: auto;
+    width: 100%;
     height: 100%;
     border-radius: 0 3px 3px 0;
 
-    object-fit: cover;
+    object-fit: contain;
 }
 
 .kg-bookmark-metadata {


### PR DESCRIPTION
This PR is to fix the default behaviour of image previews for default Casper theme.

After the change this:
![image](https://user-images.githubusercontent.com/5391396/73836830-d5b44e80-4818-11ea-966c-5ba06bb90622.png)
Becomes this:
![image](https://user-images.githubusercontent.com/5391396/73837676-9e46a180-481a-11ea-9191-57a7792244d0.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tryghost/casper/679)
<!-- Reviewable:end -->
