### PR TITLE
Change border-left on blockquote to use color variables

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1169,7 +1169,7 @@ Usage (In Ghost editor):
 .post-full-content blockquote {
     margin: 0 0 1.5em;
     padding: 0 1.5em;
-    border-left: #3eb0ef 3px solid;
+    border-left: color(var(--blue)) 3px solid;
 }
 @media (max-width: 500px) {
     .post-full-content blockquote {


### PR DESCRIPTION
The blockquote is using a hardcoded color in `screen.css`. I've changed it to use the `color(var(--primary))` instead.