### PR TITLE
Use date format 'll' instead of 'D MMM YYYY'

### DIFF
--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -61,7 +61,7 @@
             </ul>
             <div class="post-card-byline-content">
                 <span>{{#has author="count:>2"}}Multiple authors{{else}}{{authors}}{{/has}}</span>
-                <span class="post-card-byline-date"><time datetime="{{date format="YYYY-MM-DD"}}">{{date format="D MMM YYYY"}}</time> <span class="bull">&bull;</span> {{reading_time}}</span>
+                <span class="post-card-byline-date"><time datetime="{{date format="YYYY-MM-DD"}}">{{date format="ll"}}</time> <span class="bull">&bull;</span> {{reading_time}}</span>
             </div>
         </footer>
 

--- a/post.hbs
+++ b/post.hbs
@@ -74,7 +74,7 @@ into the {body} of the default.hbs template --}}
                         <section class="post-full-byline-meta">
                             <h4 class="author-name">{{authors}}</h4>
                             <div class="byline-meta-content">
-                                <time class="byline-meta-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="D MMM YYYY"}}</time>
+                                <time class="byline-meta-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="ll"}}</time>
                                 <span class="byline-reading-time"><span class="bull">&bull;</span> {{reading_time}}</span>
                             </div>
                         </section>
@@ -144,7 +144,7 @@ into the {body} of the default.hbs template --}}
                             <li>
                                 <h4><a href="{{url}}">{{title}}</a></h4>
                                 <div class="read-next-card-meta">
-                                    <p><time datetime="{{date format="YYYY-MM-DD"}}">{{date format="D MMM YYYY"}}</time> –
+                                    <p><time datetime="{{date format="YYYY-MM-DD"}}">{{date format="ll"}}</time> –
                                         {{reading_time}}</p>
                                 </div>
                             </li>


### PR DESCRIPTION
The date format 'D MMM YYYY' used by Casper is for specific locales such as UK.
Please use localized format 'll' because preferred formatting differs based on locale.

| Locale | Format 'D MMM YYYY' | Format 'll' |
| --- | --- | --- |
| de | 15 NOV. 2020 | 15. NOV. 2020 |
| en | 15 NOV 2020 | NOV 15, 2020 |
| en-ca | 15 NOV 2020 | NOV 15, 2020 |
| en-gb | 15 NOV 2020 | 15 NOV 2020 |
| en-us | 15 NOV 2020 | NOV 15, 2020 |
| fr | 15 NOV. 2020 | 15 NOV. 2020 |
| it | 15 NOV 2020 | 15 NOV 2020 |
| ja | 15 11月 2020 | 2020年11月15日 |
| zh-cn | 15 11月 2020 | 2020年11月15日 |

*Locale: Sets to General settings -> Publication Language