### PR TITLE
Only use post-card-large variation if feature_image exists

### DIFF
--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -1,7 +1,7 @@
 {{!-- This is a partial file used to generate a post "card"
 which templates loop over to generate a list of posts. --}}
 
-<article class="post-card {{post_class}} {{#is "home"}}{{#has index="0"}}post-card-large{{/has}}{{/is}}">
+<article class="post-card {{post_class}} {{#is "home"}}{{#if feature_image}}{{#has index="0"}}post-card-large{{/has}}{{/if}}{{/is}}">
 
     {{#if feature_image}}
     <a class="post-card-image-link" href="{{url}}">


### PR DESCRIPTION
If the first post has no `feature_image`, it was still incorrectly displayed as a large card.

This PR adds another conditional to check `feature_image` exists. With this, the large variation will only be used if:
* is home page
* `feature_image` exists
* is the first newest post

## Before:

![1615480077927](https://user-images.githubusercontent.com/390392/110820493-0f128580-8287-11eb-8cbf-92c9094e960b.png)

## After:

![1615480135577](https://user-images.githubusercontent.com/390392/110820505-1174df80-8287-11eb-811f-9db21e2ce4e8.png)