### PR TITLE
Make <kbd> tag look more like a button

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -169,8 +169,21 @@ svg:not(:root) {
 mark {
     background-color: #fdffb6;
 }
+kbd {
+  display: inline-block;
+  margin: 0, 0.1rem;
+  padding: 0.1em 0.6em;
+  overflow-wrap: break-word;
+  color: #232629;
+  background-color: #e3e6e8;
+  border: 1px solid #9fa6ad;
+  border-radius: 3px;
+  box-shadow: 0 1px 1px hsl(210deg 8% 5% / 15%),
+    inset 0 1px 0 0 hsl(0deg 0% 100%);
+  font-family: monospace;
+  line-height: 1.5;
+}
 code,
-kbd,
 pre,
 samp {
     font-family: monospace, monospace;


### PR DESCRIPTION
The kbd tag is often used in tech articles and it doesn't look nice at the moment. By the way, it's also looking wrong in the editor.
That's how it should look after this change.

![image](https://user-images.githubusercontent.com/10460752/137621720-c7927937-03ef-4de8-9c2d-50a6d14210e6.png)
