### PR TITLE
Change Subscribe button to Login

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -61,7 +61,7 @@
                 </div>
 
                 {{#unless @member}}
-                    <a class="gh-head-button" href="#/portal/signup" data-portal="signup">Subscribe</a>
+                    <a class="gh-head-button" href="#/portal/signin" data-portal="signin">Login</a>
                 {{else}}
                     <a class="gh-head-button" href="#/portal/account" data-portal="account">Account</a>
                 {{/unless}}


### PR DESCRIPTION
The Subscribe/Account button flow is confusing for... everyone. If a member signs up, but signs out and returns to the site, where should they click to sign back in? Seeing the only Subscribe button, they are confuse...

... because new members don't expect to see Subscribe in that position after they've signed up. In [the Edition theme](https://edition.ghost.io/), the Login/Account button states are much more intuitive.

Also, site owners can use the Portal subscribe buttons anywhere in their theme, including the home page, so a Subscribe button in the header isn't necessary.

(Having both Login and Subscribe is also possible—like [in the Dawn theme](https://dawn.ghost.io/)—but again, the additional Subscribe link in the header is just clutter for signed-in members.)