### PR TITLE
Let social links inherit their color

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -373,7 +373,7 @@ body:not(.has-cover) .site-header-content:not(.left-aligned) {
 
 .gh-social-link {
     line-height: 0;
-    color: #fff;
+    color: inherit;
 }
 
 .gh-social-link:hover {


### PR DESCRIPTION
Hey there 👋!

The color of social links is currently set to `#fff`, which renders the social links invisible with the light color scheme and disabled publication cover.

When setting it to `inherit`, the color is inherited to be `var(--color-darkgrey)` in light mode, and `#fff` in dark mode.

:octocat: 

PS: I haven't seriously worked with CSS for quite some time, so I hope this was the correct location. I made the change with code injection, and as usual, it works on my machine 😅 