### PR TITLE
Add `me` relation to social links

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -44,10 +44,10 @@
             <div class="gh-head-actions">
                 <div class="gh-social">
                     {{#if @site.facebook}}
-                        <a class="gh-social-link gh-social-facebook" href="{{facebook_url @site.facebook}}" title="Facebook" target="_blank" rel="noopener">{{> "icons/facebook"}}</a>
+                        <a class="gh-social-link gh-social-facebook" href="{{facebook_url @site.facebook}}" title="Facebook" target="_blank" rel="me noopener">{{> "icons/facebook"}}</a>
                     {{/if}}
                     {{#if @site.twitter}}
-                        <a class="gh-social-link gh-social-twitter" href="{{twitter_url @site.twitter}}" title="Twitter" target="_blank" rel="noopener">{{> "icons/twitter"}}</a>
+                        <a class="gh-social-link gh-social-twitter" href="{{twitter_url @site.twitter}}" title="Twitter" target="_blank" rel="me noopener">{{> "icons/twitter"}}</a>
                     {{/if}}
                 </div>
                 {{#if @site.members_enabled}}


### PR DESCRIPTION
Hi there 👋,

The [Microformats spec](https://microformats.org/wiki/rel-me#example) says that

> rel="me" is used on hyperlinks from one page about a person to other pages about that same person. 

It's no hard argument, but at least Github adds this to URLs as well 😅, and [Twitter recommends it in their developer docs](https://developer.twitter.com/en/docs/twitter-for-websites/webpage-properties) (in the "Identify the Twitter profile of the page" section).

<img src="https://user-images.githubusercontent.com/67554/172613298-d2ef951a-863d-40a2-8392-4d6723e5bfa2.png" width="400" />

:octocat:
