### PR TITLE
Fix missing space between paragraphs within a blockquote.

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1081,6 +1081,18 @@ is the very first element in the post content */
     margin-top: max(4.8vmin, 32px) !important;
 }
 
+/* Within a blockquote, no margin is needed at the top or bottom
+but do include space between multiple paragraphs */
+.gh-content > blockquote p:first-child {
+    margin-top: 0;
+}
+.gh-content > blockquote p {
+    margin: 1.5rem;
+}
+.gh-content > blockquote p:last-child {
+    margin-bottom: 0;
+}
+
 /* Now the content typography styles */
 .gh-content a {
     color: var(--ghost-accent-color);


### PR DESCRIPTION
I'll upload screenshots to show the before/after difference.

## Before

No space between paragraphs in blockquotes.
![image](https://user-images.githubusercontent.com/25829/177799527-d048ac35-80ab-4b05-9069-21b219258b66.png)

## After

Space between paragraphs in block quotes,  but not at the top or bottom. The blockquote already provides margin around the whole feature.

![image](https://user-images.githubusercontent.com/25829/177799713-b8651a45-f156-49c3-8121-3b3be219b0c0.png)

If users have multiple paragraphs within a blockquote, presumably there are there for a reason. If you don't want the space in your blockquotes, don't use multiple paragraphs. 