### PR TITLE
re-add aria-label to search button for screen readers

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -31,7 +31,7 @@
                         {{@site.title}}
                     {{/if}}
                 </a>
-                <button class="gh-search gh-icon-btn" data-ghost-search>{{> "icons/search"}}</button>
+                <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
                 <button class="gh-burger"></button>
             </div>
 
@@ -39,7 +39,7 @@
                 {{navigation}}
                 {{#unless @site.members_enabled}}
                     {{#match @custom.navigation_layout "Stacked"}}
-                        <button class="gh-search gh-icon-btn" data-ghost-search>{{> "icons/search"}}</button>
+                        <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>
                     {{/match}}
                 {{/unless}}
             </nav>


### PR DESCRIPTION
This was added by https://github.com/TryGhost/Casper/pull/896 

but then appears to have been accidentally reverted in the merge of https://github.com/TryGhost/Casper/pull/906