### PR TITLE
Fix primary navigation not showing when screen is wide

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -475,13 +475,6 @@ production stylesheet in assets/built/screen.css
     height: 24px;
 }
 
-@media (min-width: 992px) {
-    body:not(.is-dropdown-loaded) .gh-head-menu .nav > li {
-        opacity: 0;
-    }
-}
-
-
 /* Dropdown
 /* ---------------------------------------------------------- */
 


### PR DESCRIPTION
This theme was not working for me - on big screens like computers, the text was dark on dark mode, and when I hovered over the items the links were still present. I noticed resizing it made my menu items appear. Removed a line specifying opacity on bigger screens.

My settings:
show publication cover: off
color scheme: auto
navigation layout: logo on cover

I'm not sure if doing this will break something else, this quick fix looked okay to me on my blog at https://adventgineering.org/