### PR TITLE
[Fix] images added to posts in markdown are displayed differently than images added using the '+' button #952

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1401,6 +1401,10 @@ is the very first element in the post content */
     line-height: 1.6em;
 }
 
+.gh-content > p img {
+  margin: 0 auto;
+}
+
 .page-template .gh-content:only-child > *:first-child:not(.kg-width-full) {
     margin-top: max(12vmin, 64px);
 }


### PR DESCRIPTION
Fix Issue:- #952 

Problem:
Images added to posts in Markdown are left-aligned instead of center aligned, and they do not display the caption underneath. This behavior differs from images added to posts using the '+' button in the editor.

![Screenshot 2023-08-12 at 5 50 04 PM](https://github.com/TryGhost/Casper/assets/24241624/c3093aee-2499-4117-9ec5-020ac07d1414)


Fix:
Images added to posts using Markdown are displayed the same as images added to posts using the '+' button in the editor. This means they should be center aligned and the caption should be displayed if a caption is provided.

![Screenshot 2023-08-12 at 5 50 50 PM](https://github.com/TryGhost/Casper/assets/24241624/a1d96bbb-6ca1-40e5-bd59-0ad11af01eb8)
