### PR TITLE
Adding translation ability to theme

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -58,13 +58,13 @@
                     <div class="gh-head-members">
                         {{#unless @member}}
                             {{#unless @site.members_invite_only}}
-                                <a class="gh-head-link" href="#/portal/signin" data-portal="signin">Sign in</a>
-                                <a class="gh-head-button" href="#/portal/signup" data-portal="signup">Subscribe</a>
+                                <a class="gh-head-link" href="#/portal/signin" data-portal="signin">{{t "Sign in"}}</a>
+                                <a class="gh-head-button" href="#/portal/signup" data-portal="signup">{{t "Subscribe"}}</a>
                             {{else}}
-                                <a class="gh-head-button" href="#/portal/signin" data-portal="signin">Sign in</a>
+                                <a class="gh-head-button" href="#/portal/signin" data-portal="signin">{{t "Sign in"}}</a>
                             {{/unless}}
                         {{else}}
-                            <a class="gh-head-button" href="#/portal/account" data-portal="account">Account</a>
+                            <a class="gh-head-button" href="#/portal/account" data-portal="account">{{t "Account"}}</a>
                         {{/unless}}
                     </div>
                 {{/unless}}
@@ -84,7 +84,7 @@
             <nav class="site-footer-nav">
                 {{navigation type="secondary"}}
             </nav>
-            <div class="gh-powered-by"><a href="https://ghost.org/" target="_blank" rel="noopener">Powered by Ghost</a></div>
+            <div class="gh-powered-by"><a href="https://ghost.org/" target="_blank" rel="noopener">{{t "Powered by Ghost"}}</a></div>
         </div>
     </footer>
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,19 @@
+{
+    "Subscribe": "Subscribe",
+    "Sign in": "Sign in",
+    "Account": "Account",
+    "Powered by Ghost": "Powered by Ghost",
+    "Featured": "Featured",
+    "Enter your email": "Enter your email",
+    "zero posts": "zero posts",
+    "% post": "% post",
+    "% posts": "% posts",
+    "Close (Esc)": "Close (Esc)",
+    "Share": "Share",
+    "Toggle fullscreen": "Toggle fullscreen",
+    "Zoom in/out": "Zoom in/out",
+    "Previous (arrow left)": "Previous (arrow left)",
+    "Next (arrow right)": "Next (arrow right)",
+    "Members only": "Members only",
+    "Paid-members only": "Paid-members only"
+}

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -1,0 +1,19 @@
+{
+    "Subscribe": "Đăng ký",
+    "Sign in": "Đăng nhập",
+    "Account": "Tài khoản",
+    "Powered by Ghost": "Được xây dựng với Ghost",
+    "Featured": "Nổi bật",
+    "Enter your email": "Nhập địa chỉ email",
+    "zero posts": "không bài viết",
+    "% post": "% bài viết",
+    "% posts": "% bài viết",
+    "Close (Esc)": "Đóng (Esc)",
+    "Share": "Chia sẻ",
+    "Toggle fullscreen": "Chuyển đổi toàn màn hình",
+    "Zoom in/out": "Phóng to/Thu nhỏ",
+    "Previous (arrow left)": "Trước (mũi tên trái)",
+    "Next (arrow right)": "Tiếp (mũi tên phải)",
+    "Members only": "Chỉ thành viên",
+    "Paid-members only": "Chỉ thành viên trả phí"
+}

--- a/partials/lightbox.hbs
+++ b/partials/lightbox.hbs
@@ -12,10 +12,10 @@
             <div class="pswp__top-bar">
                 <div class="pswp__counter"></div>
 
-                <button class="pswp__button pswp__button--close" title="Close (Esc)"></button>
-                <button class="pswp__button pswp__button--share" title="Share"></button>
-                <button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
-                <button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
+                <button class="pswp__button pswp__button--close" title="{{t "Close (Esc)"}}"></button>
+                <button class="pswp__button pswp__button--share" title="{{t "Share"}}"></button>
+                <button class="pswp__button pswp__button--fs" title="{{t "Toggle fullscreen"}}"></button>
+                <button class="pswp__button pswp__button--zoom" title="{{t "Zoom in/out"}}"></button>
 
                 <div class="pswp__preloader">
                     <div class="pswp__preloader__icn">
@@ -30,8 +30,8 @@
                 <div class="pswp__share-tooltip"></div>
             </div>
 
-            <button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)"></button>
-            <button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)"></button>
+            <button class="pswp__button pswp__button--arrow--left" title="{{t "Previous (arrow left)"}}"></button>
+            <button class="pswp__button pswp__button--arrow--right" title="{{t "Next (arrow right)"}}"></button>
 
             <div class="pswp__caption">
                 <div class="pswp__caption__center"></div>

--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -24,9 +24,9 @@ which templates loop over to generate a list of posts. --}}
             <div class="post-card-access">
                 {{> "icons/lock"}}
                 {{#has visibility="members"}}
-                    Members only
+                    {{t "Members only"}}
                 {{else}}
-                    Paid-members only
+                    {{t "Paid-members only"}}
                 {{/has}}
             </div>
         {{/has}}
@@ -44,7 +44,7 @@ which templates loop over to generate a list of posts. --}}
                         <span class="post-card-primary-tag">{{name}}</span>
                     {{/primary_tag}}
                     {{#if featured}}
-                        <span class="post-card-featured">{{> "icons/fire"}} Featured</span>
+                        <span class="post-card-featured">{{> "icons/fire"}} {{t "Featured"}}</span>
                     {{/if}}
                 </div>
                 <h2 class="post-card-title">

--- a/post.hbs
+++ b/post.hbs
@@ -19,7 +19,7 @@ into the {body} tag of the default.hbs template --}}
                 </span>
             {{/primary_tag}}
             {{#if featured}}
-                <span class="post-card-featured">{{> "icons/fire"}} Featured</span>
+                <span class="post-card-featured">{{> "icons/fire"}} {{t "Featured"}}</span>
             {{/if}}
         </div>
 
@@ -104,8 +104,8 @@ into the {body} tag of the default.hbs template --}}
         <div class="inner">
             {{#if @custom.email_signup_text}}<h2 class="footer-cta-title">{{@custom.email_signup_text}}</h2>{{/if}}
             <a class="footer-cta-button" href="#/portal" data-portal>
-                <div class="footer-cta-input">Enter your email</div>
-                <span>Subscribe</span>
+                <div class="footer-cta-input">{{t "Enter your email"}}</div>
+                <span>{{t "Subscribe"}}</span>
             </a>
         </div>
     </section>


### PR DESCRIPTION
I know, I'm not the sharpest tool in the shed, so I hope this will help out our use case and other users who need translations in the theme.

#Copilot summary
This pull request focuses on adding internationalization support to various templates by replacing hardcoded text with translation keys. The changes span multiple template files and include English and Vietnamese locales.