### PR TITLE
Update image lazy loading behavior in post-card.hbs

### DIFF
--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -16,7 +16,7 @@ which templates loop over to generate a list of posts. --}}
             sizes="(max-width: 1000px) 400px, 800px"
             src="{{img_url feature_image size="m"}}"
             alt="{{#if feature_image_alt}}{{feature_image_alt}}{{else}}{{title}}{{/if}}"
-            loading="lazy"
+            loading="{{#if @index}}lazy{{else}}eager{{/if}}"
         />
 
         {{#unless access}}


### PR DESCRIPTION
## Description
- Disabled lazy loading for the first image to improve perceived page load speed and Largest Contentful Paint (LCP) metrics.
- Updated the `loading` attribute to be dynamic:
  ```hbs
  loading="{{#if @index}}lazy{{else}}eager{{/if}}"
  ```
- The first image (@index = 0) now uses eager loading.
- All subsequent images continue to use lazy loading.

## Why: 

Improving the loading strategy for critical content enhances user experience and boosts SEO performance by optimizing core web vitals