### PR TITLE
Added GitHub Actions workflow to run theme tests on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: lts/*
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - run: yarn install --frozen-lockfile
+
+      - run: yarn test:ci


### PR DESCRIPTION
## Summary

Adds a `test.yml` GitHub Actions workflow that runs the theme test suite (`yarn test:ci`, i.e. gscan validation) on every pull request, giving us automated theme checks before changes are merged.

## Details

The workflow was adapted from the Zap repo, which uses **pnpm**. Since Casper uses **yarn** (`yarn.lock`), the toolchain setup was switched accordingly:

- Removed the `pnpm/action-setup` step
- `actions/setup-node` now uses `cache: yarn` keyed on `yarn.lock`
- Installs with `yarn install --frozen-lockfile` for reproducible CI installs

The `run:` steps (`yarn install` / `yarn test:ci`) were already yarn-based; only the toolchain setup and dependency cache needed correcting.