### PR TITLE
Added GitHub Actions workflow to test and deploy theme to Ghost

### DIFF
--- a/.github/workflows/deploy-theme.yml
+++ b/.github/workflows/deploy-theme.yml
@@ -1,0 +1,48 @@
+# Learn more → https://github.com/TryGhost/action-deploy-theme#getting-started
+name: Deploy Theme
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - uses: yarn/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: lts/*
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - run: yarn install --frozen-lockfile
+
+      - run: yarn test:ci
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Deploy theme
+        uses: TryGhost/action-deploy-theme@a0ee1147d15641db25681e54549c4db9a53c2629
+        with:
+          api-url: ${{ secrets.GHOST_ADMIN_API_URL }}
+          api-key: ${{ secrets.GHOST_ADMIN_API_KEY }}

--- a/.github/workflows/deploy-theme.yml
+++ b/.github/workflows/deploy-theme.yml
@@ -19,8 +19,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: yarn/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
-
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: lts/*


### PR DESCRIPTION
## Summary

Adds `.github/workflows/deploy-theme.yml` so pushes to `main` automatically run the test suite and, on success, deploy the theme to Ghost.

## What changed

- **Test job** — runs `yarn install --frozen-lockfile` and `yarn test:ci` on `ubuntu-latest`.
- **Deploy job** — gated on the test job (`needs: test`), deploys via `TryGhost/action-deploy-theme`.
- Credentials are read from the `GHOST_ADMIN_API_URL` and `GHOST_ADMIN_API_KEY` repository secrets.
- All action references are pinned to commit SHAs with `persist-credentials: false` and least-privilege `contents: read` permissions.

## Why

This removes the manual upload step from the release process, ensuring the live theme always reflects the latest tested code on `main`.