### PR TITLE
Fixed Deploy Theme failure by setting a non-default theme-name

### DIFF
--- a/.github/workflows/deploy-theme.yml
+++ b/.github/workflows/deploy-theme.yml
@@ -44,3 +44,4 @@ jobs:
         with:
           api-url: ${{ secrets.GHOST_ADMIN_API_URL }}
           api-key: ${{ secrets.GHOST_ADMIN_API_KEY }}
+          theme-name: Casper-Main


### PR DESCRIPTION
## Problem

The **Deploy Theme** workflow fails on every push to `main`:

```
Error [ValidationError]: Please rename your zip, it's not allowed to override the default theme.
```

`TryGhost/action-deploy-theme` derives the theme name from `package.json`, which is `casper`. Ghost reserves `casper` for its built-in default theme and refuses to let an upload overwrite it, so the deploy step always errors out (see [failed run](https://github.com/TryGhost/Casper/actions/runs/26875854650)).

## Fix

Add a `theme-name: Casper-Main` input to the deploy step so the theme deploys under a distinct name. This keeps it separate from the currently active `Casper-Master` theme on the target site.

## Verification

- Confirmed the action exposes a `theme-name` input ("A custom theme name that overrides the default name in package.json").
- Confirmed the failure cause in the run log: the zip is built as `casper` and rejected by Ghost's default-theme protection.