### PR TITLE
Fixed broken pnpm/action-setup pin and excluded workspace file from zip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -85,6 +85,7 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-debug.log',
             '!pnpm-lock.yaml',
+            '!pnpm-workspace.yaml',
             '!gulpfile.js'
         ]),
         zip(filename),


### PR DESCRIPTION
## Summary

- **Fixed the broken `pnpm/action-setup` pin in `.github/workflows/test.yml`.** The previously pinned digest `ac6db6d3c1f721f886538a378a2d73e85697340a` no longer exists upstream — GitHub returns HTTP 422 for it — so the workflow fails to resolve the action. Replaced it with `0e279bb959325dab635dd2c09392533439d90093`, the verified digest behind the current `v6`/`v6.0.8` tag.
- **Excluded `pnpm-workspace.yaml` from the theme zip** in `gulpfile.js`. The file only carries development tooling (pnpm 11 build-script approvals) and does not belong in the installable theme zip; it is now excluded alongside `pnpm-lock.yaml`.

Found via review of TryGhost/Themes#529.

## Verification

- `gh api repos/pnpm/action-setup/commits/<sha>`: old digest returns HTTP 422, new digest resolves.
- `pnpm install --frozen-lockfile` — succeeds.
- `pnpm zip` — builds and produces `dist/casper.zip`.
- `unzip -l dist/*.zip | grep pnpm` — returns nothing, confirming neither `pnpm-workspace.yaml` nor `pnpm-lock.yaml` is in the zip.