### PR TITLE
Add theme CI gate and agent docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,13 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm test:ci
+
+  all-tests-pass:
+    name: All tests pass
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Scope
+
+This repository is the classic Ghost theme. Keep changes focused on theme source, generated assets, CI, and repo-level metadata for this repository.
+
+## Commands
+
+Use pnpm for this repo, pinned by package.json.
+
+```bash
+pnpm install --frozen-lockfile
+pnpm dev
+pnpm test:ci
+pnpm zip
+```
+
+Run the test command before opening a PR when theme files, generated assets, dependencies, or CI change.
+
+## Boundaries
+
+- Edit source CSS, JavaScript, Handlebars templates, partials, and package metadata intentionally.
+- Keep generated assets/built/ files in sync when source assets change and the repo tracks those outputs.
+- Do not commit node_modules/, local Ghost content, generated zip files outside tracked release expectations, or secrets.
+- Repo settings, descriptions, and branch rules belong on the GitHub repository; internal clean-repos metadata stays in TryGhost/cleanrepos.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- add a stable `All tests pass` gate to the pull request test workflow
- add concise `AGENTS.md` guidance for theme development boundaries and validation
- add `CLAUDE.md` as a symlink to `AGENTS.md`

## Validation
- Ruby YAML parse over `.github/workflows/*.yml`
- verified `CLAUDE.md` points to `AGENTS.md`
