### PR TITLE
🐛 Fixed comment count not respecting theme translations

### DIFF
--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -69,7 +69,7 @@ which templates loop over to generate a list of posts. --}}
                 <span class="post-card-meta-length">{{reading_time minute=(t "1 min read") minutes=(t "% min read")}}</span>
             {{/if}}
             {{#if @site.comments_enabled}}
-                {{comment_count}}
+                {{comment_count singular=(t "comment") plural=(t "comments")}}
             {{/if}}
         </footer>
 


### PR DESCRIPTION
Post cards render the comment count with the bare `{{comment_count}}` helper. That helper falls back to the hardcoded English comment/comments defaults, so the count is always displayed in English regardless of the site's publication language.

This fix pass singular / plural through the `{{t}}` helper, using the same translation pattern already applied to `reading_time` on the line above.

FYI: The same bare `{{comment_count}}` pattern appears in other official themes (Edition, Solo, Headline). 