### PR TITLE
Renamed CI gate check to the org-standard "Required checks pass"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
 
       - run: pnpm test:ci
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Branch protection on this repo currently requires a status check named exactly `All tests pass`. Requiring a legacy, repo-specific check name couples branch protection to the CI job naming: rename that job (or restructure the workflow) and the required check silently stops existing, blocking every PR.

The org is standardizing every repo on one stable aggregator check named `Required checks pass` (the aggregator-gate convention), so branch protection has a single stable target across all repos.

## What

- Renamed the gate job id `all-tests-pass` -> `required-checks-pass` and its `name` to `Required checks pass`.
- No behaviour change: the gate still `needs` every job in the workflow (`test`), still runs with `if: always()`, and still fails when any needed job failed or was cancelled. Top-level `permissions: contents: read` was already in place.

## Merge coordination

The branch ruleset is being updated in the same pass to require `Required checks pass` instead of `All tests pass`, so this PR must go green on the new gate before merge.