### PR TITLE
Apply explicit pnpm security baseline

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,14 @@
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
+
 allowBuilds:
   # Optional dtrace bindings for bunyan (a gscan dependency); not needed to build/test the theme.
   dtrace-provider: false
 
-# pnpm 11.5's default minimumReleaseAge supply-chain policy rejects packages
-# published within the last 24h. @tryghost/theme-translations is a first-party
+# The release-age supply-chain policy rejects packages published within the
+# last 72h. @tryghost/theme-translations is a first-party
 # Ghost dependency we pin exactly, so exclude its current version from the age
-# gate (it would otherwise fail CI for a day after each release bump).
+# gate (it would otherwise fail CI after each release bump).
 minimumReleaseAgeExclude:
   - '@tryghost/theme-translations'


### PR DESCRIPTION
## What changed

- make Casper's 72-hour dependency cooldown explicit with minimumReleaseAge: 4320
- fail closed on unreviewed dependency builds with strictDepBuilds: true
- reject exotic transitive dependency sources with blockExoticSubdeps: true
- preserve the existing dtrace-provider denial and the pinned first-party theme-translations age exclusion
- update the age-policy comment from the old implicit 24-hour behavior to the explicit 72-hour policy

## Why

Casper previously relied on pnpm's 24-hour default release-age policy and implicit defaults for unknown builds and exotic transitive sources. Making these settings explicit prevents package-manager default changes from silently weakening the repository's supply-chain controls.

Casper has no allowed lifecycle-script entries, so this PR authorizes no package builds. The release ZIP intentionally excludes both pnpm-workspace.yaml and pnpm-lock.yaml and contains no install environment; the policy remains enforced at the standalone repository root where dependencies are installed.

This is the Casper portion of [PLA-321](https://linear.app/ghost/issue/PLA-321/make-the-72-hour-pnpm-cooldown-explicit-across-first-party-themes).

## Validation

- pnpm 11.19.0 install --frozen-lockfile; lockfile passed supply-chain policy verification
- pnpm build
- pnpm test:ci; theme rebuilt, packaged, and passed fatal gscan
- release ZIP integrity check
- gscan --fatal --verbose -z dist/casper.zip
- confirmed release ZIP excludes pnpm install metadata
- generated assets remain unchanged
- git diff --check